### PR TITLE
feat: make Loop dialog responsive

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A drop-in `/loop` command for [opencode](https://opencode.ai), modeled after Cla
 - **LLM-callable tools** — `loop_schedule`, `loop_status` (session-bound by default)
 - **Interactive Loop results** — `/loop` results open in a dedicated native dialog instead of writing over the prompt
 - **Clipboard actions** — copy the complete result or copy any displayed task ID with one action
+- **Responsive layout** — short or narrow terminals keep the dialog inside the viewport with independently scrollable result and action areas
 - **Easy dismissal** — choose **Close**, press `q`, or use the native dialog's `Esc` key
 
 ## Requirements
@@ -39,14 +40,14 @@ The scheduling server plugin still has a native toast fallback, while supported 
 Use OpenCode's plugin installer so the package's server and TUI entrypoints are both detected and added to the correct configs:
 
 ```bash
-opencode plugin opencode-plugin-loop@0.2.5 --global --force
+opencode plugin opencode-plugin-loop@0.2.6 --global --force
 ```
 
-This pins version 0.2.5 and updates both global `opencode.json` and `tui.json`.
+This pins version 0.2.6 and updates both global `opencode.json` and `tui.json`.
 
 If `/loop` is not already defined in your OpenCode configuration, add the command definition shown below to `opencode.json`. OpenCode detects both plugin entrypoints from the npm package, but it does not currently copy the bundled `commands/loop.md` file into your config directory.
 
-To upgrade after a newer version is released, replace `0.2.5` in the command with the target version and run it again with `--force`.
+To upgrade after a newer version is released, replace `0.2.6` in the command with the target version and run it again with `--force`.
 
 ### Option 2: Manual configuration
 
@@ -56,7 +57,7 @@ Server config (`~/.config/opencode/opencode.json`):
 
 ```json
 {
-  "plugin": ["opencode-plugin-loop@0.2.5"],
+  "plugin": ["opencode-plugin-loop@0.2.6"],
   "command": {
     "loop": {
       "description": "定时重复执行 prompt。可选间隔: s/m/h/d。子命令: list | status | cancel <id> | pause <id> | resume <id> | stop-all（加 --all 跨 session）",
@@ -72,7 +73,7 @@ TUI config (`~/.config/opencode/tui.json`):
 ```json
 {
   "$schema": "https://opencode.ai/tui.json",
-  "plugin": ["opencode-plugin-loop@0.2.5"]
+  "plugin": ["opencode-plugin-loop@0.2.6"]
 }
 ```
 
@@ -138,7 +139,7 @@ Every `/loop` command result opens in a separate native OpenCode dialog. It keep
 - **Copy all** for the exact complete result text
 - **Close** to dismiss the dialog
 
-Use the mouse or arrow keys to select an action, then press `Enter` or `Space`. Press `q` or `Esc` to close. A newer Loop result replaces the previous Loop dialog rather than stacking another one.
+Use the mouse or arrow keys to select an action, then press `Enter` or `Space`. A successful **Copy ID** or **Copy all** action shows a confirmation and closes the dialog immediately; if clipboard access fails, the dialog stays open and shows an error. Press `Page Up` or `Page Down` to scroll long result text, or press `q` or `Esc` to close. In short or narrow terminals, the dialog scales to the available viewport and keeps the result and action lists independently scrollable. A newer Loop result replaces the previous Loop dialog rather than stacking another one.
 
 ### Programmatic (LLM tools)
 
@@ -204,9 +205,9 @@ Tasks persist to `.opencode/cache/loop/tasks.json` (per project). Fire history i
 
 ## Troubleshooting
 
-### Package entrypoints in 0.2.5
+### Package entrypoints in 0.2.6
 
-Version 0.2.5 exposes separate `opencode-plugin-loop/server` and `opencode-plugin-loop/tui` entrypoints so OpenCode can load the scheduler and interactive dialog independently. The root export remains the v1-compatible server module for backward compatibility. Programmatic consumers should use the named factory:
+Version 0.2.6 exposes separate `opencode-plugin-loop/server` and `opencode-plugin-loop/tui` entrypoints so OpenCode can load the scheduler and responsive interactive dialog independently. The root export remains the v1-compatible server module for backward compatibility. Programmatic consumers should use the named factory:
 
 ```typescript
 import { LoopPlugin } from "opencode-plugin-loop"
@@ -214,7 +215,7 @@ import { LoopPlugin } from "opencode-plugin-loop"
 
 ### Task lines overlap the input area
 
-Versions before 0.2.4 wrote `/loop` results directly to the terminal. OpenCode owns and redraws the terminal UI, so those writes could leave task IDs and prompts over the input area. Upgrade to 0.2.5 for the dedicated interactive dialog; runtime diagnostics go to OpenCode's structured application log.
+Versions before 0.2.4 wrote `/loop` results directly to the terminal. OpenCode owns and redraws the terminal UI, so those writes could leave task IDs and prompts over the input area. Upgrade to 0.2.6 for the responsive interactive dialog; runtime diagnostics go to OpenCode's structured application log.
 
 Also make sure the plugin is installed from only one source. OpenCode loads npm plugins from `opencode.json` and copied plugins under `~/.config/opencode/plugins/` independently, even when they have the same package name.
 

--- a/docs/superpowers/plans/2026-07-15-responsive-loop-dialog.md
+++ b/docs/superpowers/plans/2026-07-15-responsive-loop-dialog.md
@@ -1,0 +1,602 @@
+# Responsive Loop Dialog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Loop dialog resize safely in short/narrow terminals and close the current dialog immediately after a successful `Copy ID` or `Copy all` action.
+
+**Architecture:** Keep OpenCode's native dialog stack and replace the built-in `DialogSelect` body with a custom OpenTUI Solid component. Pure layout and action helpers remain independent of JSX; `src/tui.ts` retains event ownership, clipboard I/O, generation-safe close behavior, and structured recovery.
+
+**Tech Stack:** TypeScript, Node test runner, OpenCode TUI plugin API 1.17.18, `@opentui/solid` 0.4.3, `@opentui/core` 0.4.3, SolidJS 1.9.12, clipboardy 4.0.0.
+
+## Global Constraints
+
+- OpenCode minimum version remains `>=1.17.18`.
+- The server entrypoint must not import OpenTUI, SolidJS, or clipboard code.
+- `Copy all` must write the exact complete Loop message without truncation or normalization.
+- A clipboard failure must keep the current dialog open.
+- A clipboard success may close only the dialog generation that initiated the write.
+- The native OpenCode dialog stack continues to own backdrop, modal focus, and `Esc`.
+- No direct stdout/stderr writes are allowed from runtime plugin code.
+- Root, `./server`, and `./tui` package entrypoints remain backward compatible.
+
+---
+
+## File structure
+
+- Create `src/tui-dialog-layout.ts`: pure responsive row allocation and action-index movement.
+- Create `src/tui-dialog-actions.ts`: action construction and generation-safe asynchronous action runner.
+- Create `src/tui-dialog-view.tsx`: responsive OpenTUI JSX view, scroll regions, selected-row presentation, and imperative keyboard ref.
+- Modify `src/tui.ts`: dialog generation ownership, keyboard layer, copy-close behavior, and view factory injection.
+- Create `tests/tui-dialog-layout.test.mjs`: layout and selection regression tests.
+- Create `tests/tui-dialog-actions.test.mjs`: copy success/failure, duplicate activation, and replacement-race tests.
+- Modify `tests/tui-plugin.test.mjs`: plugin/view integration and lifecycle behavior.
+- Modify `tests/package-exports.test.mjs`, `package.json`, `package-lock.json`, and `tsconfig.json`: TSX compilation and compatible OpenTUI peers.
+- Modify `README.md`: describe automatic close and responsive scrolling.
+
+### Task 1: Pure responsive layout and action ordering
+
+**Files:**
+- Create: `src/tui-dialog-layout.ts`
+- Test: `tests/tui-dialog-layout.test.mjs`
+
+**Interfaces:**
+- Produces: `allocateLoopDialogRows(terminalRows: number, actionCount: number): LoopDialogRows`
+- Produces: `moveLoopActionIndex(current: number, delta: number, count: number): number`
+- `LoopDialogRows` is `{ maxHeight: number; messageRows: number; actionRows: number }`.
+
+- [ ] **Step 1: Write failing layout tests**
+
+```js
+import {
+  allocateLoopDialogRows,
+  moveLoopActionIndex,
+} from "../dist/tui-dialog-layout.js"
+
+test("allocates a capped 70-percent dialog with independent viewports", () => {
+  assert.deepEqual(allocateLoopDialogRows(24, 3), {
+    maxHeight: 16,
+    messageRows: 10,
+    actionRows: 3,
+  })
+  assert.deepEqual(allocateLoopDialogRows(80, 52), {
+    maxHeight: 28,
+    messageRows: 19,
+    actionRows: 6,
+  })
+})
+
+test("never allocates beyond an extremely short terminal", () => {
+  assert.deepEqual(allocateLoopDialogRows(7, 3), {
+    maxHeight: 3,
+    messageRows: 0,
+    actionRows: 0,
+  })
+})
+
+test("action selection wraps in both directions", () => {
+  assert.equal(moveLoopActionIndex(0, -1, 3), 2)
+  assert.equal(moveLoopActionIndex(2, 1, 3), 0)
+})
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run: `npm run build && node --test tests/tui-dialog-layout.test.mjs`
+
+Expected: FAIL because `dist/tui-dialog-layout.js` does not exist.
+
+- [ ] **Step 3: Implement the pure helpers**
+
+```ts
+export interface LoopDialogRows {
+  maxHeight: number
+  messageRows: number
+  actionRows: number
+}
+
+export function allocateLoopDialogRows(terminalRows: number, actionCount: number): LoopDialogRows {
+  const rows = Math.max(1, Math.floor(terminalRows))
+  const available = Math.max(1, rows - 4)
+  const maxHeight = Math.min(28, available, Math.max(6, Math.floor(rows * 0.7)))
+  const contentRows = Math.max(0, maxHeight - 3)
+  if (contentRows < 2) return { maxHeight, messageRows: 0, actionRows: contentRows }
+  const actionRows = Math.min(
+    Math.max(0, actionCount),
+    Math.max(1, Math.min(6, Math.floor(contentRows * 0.4)))
+  )
+  return { maxHeight, messageRows: contentRows - actionRows, actionRows }
+}
+
+export function moveLoopActionIndex(current: number, delta: number, count: number): number {
+  if (count <= 0) return 0
+  return ((current + delta) % count + count) % count
+}
+```
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run: `npm run build && node --test tests/tui-dialog-layout.test.mjs`
+
+Expected: all layout tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui-dialog-layout.ts tests/tui-dialog-layout.test.mjs
+git commit -m "feat: model responsive Loop dialog layout"
+```
+
+### Task 2: Transactional dialog actions
+
+**Files:**
+- Create: `src/tui-dialog-actions.ts`
+- Test: `tests/tui-dialog-actions.test.mjs`
+
+**Interfaces:**
+- Consumes: task IDs and exact message from `createLoopFeedbackModel`.
+- Produces: `LoopDialogAction`, `createLoopDialogActions(taskIds)`, and `createLoopActionRunner(dependencies)`.
+- Runner method: `run(action: LoopDialogAction, message: string): Promise<void>` and getter `busy: boolean`.
+
+- [ ] **Step 1: Write failing transactional tests**
+
+```js
+test("successful copies close only their current generation", async () => {
+  const copied = []
+  let current = true
+  let closes = 0
+  const runner = createLoopActionRunner({
+    writeClipboard: async (text) => copied.push(text),
+    notifySuccess() {},
+    notifyFailure() {},
+    closeIfCurrent: () => { if (current) closes++ },
+  })
+  await runner.run({ type: "copy-id", taskId: "abc123" }, "full message")
+  assert.deepEqual(copied, ["abc123"])
+  assert.equal(closes, 1)
+  current = false
+  await runner.run({ type: "copy-all" }, "full message")
+  assert.equal(closes, 1)
+})
+
+test("clipboard failure keeps the dialog open", async () => {
+  let failures = 0
+  let closes = 0
+  const runner = createLoopActionRunner({
+    writeClipboard: async () => { throw new Error("denied") },
+    notifySuccess() {},
+    notifyFailure: () => failures++,
+    closeIfCurrent: () => closes++,
+  })
+  await runner.run({ type: "copy-all" }, "exact")
+  assert.equal(failures, 1)
+  assert.equal(closes, 0)
+})
+
+test("duplicate activation is ignored while copying", async () => {
+  let release
+  let writes = 0
+  const runner = createLoopActionRunner({
+    writeClipboard: () => new Promise((resolve) => { writes++; release = resolve }),
+    notifySuccess() {}, notifyFailure() {}, closeIfCurrent() {},
+  })
+  const first = runner.run({ type: "copy-all" }, "exact")
+  const second = runner.run({ type: "copy-all" }, "exact")
+  assert.equal(writes, 1)
+  release()
+  await Promise.all([first, second])
+})
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run: `npm run build && node --test tests/tui-dialog-actions.test.mjs`
+
+Expected: FAIL because the action module does not exist.
+
+- [ ] **Step 3: Implement ordered actions and runner**
+
+```ts
+export type LoopDialogAction =
+  | { type: "copy-id"; taskId: string }
+  | { type: "copy-all" }
+  | { type: "close" }
+
+export function createLoopDialogActions(taskIds: readonly string[]): readonly LoopDialogAction[] {
+  return [
+    ...taskIds.map((taskId) => ({ type: "copy-id" as const, taskId })),
+    { type: "copy-all" as const },
+    { type: "close" as const },
+  ]
+}
+
+export function createLoopActionRunner(input: {
+  writeClipboard(text: string): Promise<void>
+  notifySuccess(description: string): void
+  notifyFailure(): void
+  closeIfCurrent(): void
+}) {
+  let busy = false
+  return {
+    get busy() { return busy },
+    async run(action: LoopDialogAction, message: string) {
+      if (action.type === "close") return input.closeIfCurrent()
+      if (busy) return
+      busy = true
+      const text = action.type === "copy-all" ? message : action.taskId
+      const description = action.type === "copy-all" ? "Loop result" : `Task ID ${action.taskId}`
+      try {
+        await input.writeClipboard(text)
+        input.notifySuccess(description)
+        input.closeIfCurrent()
+      } catch {
+        input.notifyFailure()
+      } finally {
+        busy = false
+      }
+    },
+  }
+}
+```
+
+- [ ] **Step 4: Run action and layout tests**
+
+Run: `npm run build && node --test tests/tui-dialog-actions.test.mjs tests/tui-dialog-layout.test.mjs`
+
+Expected: all focused tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui-dialog-actions.ts tests/tui-dialog-actions.test.mjs
+git commit -m "feat: add transactional Loop dialog actions"
+```
+
+### Task 3: Responsive OpenTUI dialog view
+
+**Files:**
+- Create: `src/tui-dialog-view.tsx`
+- Modify: `tsconfig.json`
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `tests/package-exports.test.mjs`
+
+**Interfaces:**
+- Consumes: `LoopDialogAction[]`, exact message, variant, `TuiPluginApi`, and `allocateLoopDialogRows`.
+- Produces: `LoopFeedbackDialog(input): JSX.Element` and `LoopFeedbackDialogRef` with `move`, `activate`, `pageMessage`, and `dispose` methods.
+
+- [ ] **Step 1: Add failing packaging assertions**
+
+```js
+test("declares the host TUI peers used by the responsive dialog", () => {
+  assert.equal(packageJson.peerDependencies["@opentui/core"], ">=0.4.3")
+  assert.equal(packageJson.peerDependencies["@opentui/solid"], ">=0.4.3")
+  assert.equal(packageJson.peerDependencies["solid-js"], "1.9.12")
+})
+```
+
+- [ ] **Step 2: Run the package test and verify RED**
+
+Run: `node --test tests/package-exports.test.mjs`
+
+Expected: FAIL because the OpenTUI peers are absent.
+
+- [ ] **Step 3: Add compatible compile/runtime metadata**
+
+Run:
+
+```bash
+npm install --save-dev @opentui/core@0.4.3 @opentui/solid@0.4.3 solid-js@1.9.12
+npm pkg set 'peerDependencies.@opentui/core=>=0.4.3' \
+  'peerDependencies.@opentui/solid=>=0.4.3' \
+  'peerDependencies.solid-js=1.9.12'
+```
+
+Add to `compilerOptions` in `tsconfig.json`:
+
+```json
+"jsx": "react-jsx",
+"jsxImportSource": "@opentui/solid"
+```
+
+- [ ] **Step 4: Implement the responsive TSX view**
+
+Use `useTerminalDimensions`, `createSignal`, `createEffect`, `ScrollBoxRenderable`, and the live OpenCode theme. The root box uses `maxHeight={rows().maxHeight}`; the message and action `scrollbox` elements use `rows().messageRows` and `rows().actionRows`. Implement the view with this complete structure:
+
+```ts
+/** @jsxImportSource @opentui/solid */
+import { RGBA, TextAttributes, type ScrollBoxRenderable } from "@opentui/core"
+import { useTerminalDimensions, type JSX } from "@opentui/solid"
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import type { TuiThemeCurrent } from "@opencode-ai/plugin/tui"
+
+import type { LoopDialogAction } from "./tui-dialog-actions.js"
+import { allocateLoopDialogRows, moveLoopActionIndex } from "./tui-dialog-layout.js"
+
+export interface LoopFeedbackDialogRef {
+  move(delta: number): void
+  activate(): void
+  pageMessage(delta: number): void
+  dispose(): void
+}
+
+export interface LoopFeedbackDialogProps {
+  message: string
+  variant: "info" | "success" | "warning" | "error"
+  actions: readonly LoopDialogAction[]
+  theme: TuiThemeCurrent
+  onActivate(action: LoopDialogAction): void | Promise<void>
+  ref?(value: LoopFeedbackDialogRef | undefined): void
+}
+
+const transparent = RGBA.fromInts(0, 0, 0, 0)
+
+const label = (action: LoopDialogAction) =>
+  action.type === "copy-id" ? `Copy ID: ${action.taskId}` : action.type === "copy-all" ? "Copy all" : "Close"
+
+const description = (action: LoopDialogAction) =>
+  action.type === "copy-id"
+    ? "Copy this task ID"
+    : action.type === "copy-all"
+      ? "Copy the complete Loop result"
+      : "Close this Loop result"
+
+export function LoopFeedbackDialog(props: LoopFeedbackDialogProps): JSX.Element {
+  const dimensions = useTerminalDimensions()
+  const [selected, setSelected] = createSignal(0)
+  const rows = createMemo(() => allocateLoopDialogRows(dimensions().height, props.actions.length))
+  let messageScroll: ScrollBoxRenderable | undefined
+  let actionScroll: ScrollBoxRenderable | undefined
+
+  const keepSelectedVisible = () => {
+    const scroll = actionScroll
+    const target = scroll?.getChildren()[selected()]
+    if (!scroll || !target) return
+    const offset = target.y - scroll.y
+    if (offset < 0) scroll.scrollBy(offset)
+    if (offset >= scroll.height) scroll.scrollBy(offset - scroll.height + 1)
+  }
+
+  const controller: LoopFeedbackDialogRef = {
+    move(delta) {
+      setSelected((index) => moveLoopActionIndex(index, delta, props.actions.length))
+    },
+    activate() {
+      const action = props.actions[selected()]
+      if (action) void props.onActivate(action)
+    },
+    pageMessage(delta) {
+      if (!messageScroll) return
+      messageScroll.scrollBy(delta * Math.max(1, messageScroll.height - 1))
+    },
+    dispose() {
+      messageScroll = undefined
+      actionScroll = undefined
+    },
+  }
+
+  props.ref?.(controller)
+  createEffect(() => {
+    selected()
+    queueMicrotask(keepSelectedVisible)
+  })
+  onCleanup(() => {
+    controller.dispose()
+    props.ref?.(undefined)
+  })
+
+  const icon = () => ({ info: "ℹ", success: "✓", warning: "⚠", error: "✕" })[props.variant]
+
+  return (
+    <box maxHeight={rows().maxHeight} flexDirection="column" gap={1} paddingBottom={1}>
+      <box paddingLeft={3} paddingRight={3} flexDirection="row" justifyContent="space-between" flexShrink={0}>
+        <text fg={props.theme.text} attributes={TextAttributes.BOLD}>{icon()} Loop</text>
+        <text fg={props.theme.textMuted}>esc</text>
+      </box>
+      <Show when={rows().messageRows > 0}>
+        <scrollbox
+          ref={(value: ScrollBoxRenderable) => (messageScroll = value)}
+          maxHeight={rows().messageRows}
+          paddingLeft={3}
+          paddingRight={3}
+          scrollbarOptions={{ visible: true }}
+        >
+          <text fg={props.theme.text}>{props.message}</text>
+        </scrollbox>
+      </Show>
+      <Show when={rows().actionRows > 0}>
+        <scrollbox
+          ref={(value: ScrollBoxRenderable) => (actionScroll = value)}
+          maxHeight={rows().actionRows}
+          paddingLeft={1}
+          paddingRight={1}
+          scrollbarOptions={{ visible: false }}
+        >
+          <For each={props.actions}>{(action, index) => {
+            const active = () => selected() === index()
+            return (
+              <box
+                paddingLeft={2}
+                paddingRight={2}
+                flexDirection="row"
+                gap={1}
+                backgroundColor={active() ? props.theme.primary : transparent}
+                onMouseDown={() => setSelected(index())}
+                onMouseUp={() => void props.onActivate(action)}
+              >
+                <text fg={active() ? props.theme.selectedListItemText : props.theme.text} attributes={active() ? TextAttributes.BOLD : undefined}>
+                  {label(action)}
+                </text>
+                <text fg={active() ? props.theme.selectedListItemText : props.theme.textMuted}>{description(action)}</text>
+              </box>
+            )
+          }}</For>
+        </scrollbox>
+      </Show>
+    </box>
+  )
+}
+```
+
+The message text uses OpenTUI's normal wrapping, so the scrollbox—not a title row—owns the wrapped height.
+
+- [ ] **Step 5: Build and verify package tests GREEN**
+
+Run: `npm run build && node --test tests/package-exports.test.mjs tests/tui-dialog-layout.test.mjs`
+
+Expected: build succeeds and all focused tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tui-dialog-view.tsx tsconfig.json package.json package-lock.json tests/package-exports.test.mjs
+git commit -m "feat: render responsive Loop feedback dialog"
+```
+
+### Task 4: Integrate copy-close and responsive keyboard lifecycle
+
+**Files:**
+- Modify: `src/tui.ts`
+- Modify: `tests/tui-plugin.test.mjs`
+
+**Interfaces:**
+- Consumes: `createLoopDialogActions`, `createLoopActionRunner`, `LoopFeedbackDialog`, and `LoopFeedbackDialogRef`.
+- Preserves: default export `{ id: "opencode-plugin-loop-tui", tui }`.
+
+- [ ] **Step 1: Change integration tests to require close-on-success**
+
+Update `Copy ID` and `Copy all` tests so each asserts:
+
+```js
+assert.equal(api.ui.dialog.open, true)
+select(api, "Copy ID: task01")
+await settle()
+assert.deepEqual(copied, ["task01"])
+assert.equal(api.ui.dialog.open, false)
+assert.equal(api.__layers.filter((layer) => layer.active).length, 0)
+```
+
+Keep the clipboard-error test asserting `api.ui.dialog.open === true`.
+
+Add a deferred clipboard test that opens a second Loop event before the first copy resolves and asserts the second dialog remains open.
+
+- [ ] **Step 2: Run focused integration tests and verify RED**
+
+Run: `npm run build && node --test tests/tui-plugin.test.mjs`
+
+Expected: copy-success assertions FAIL because the dialog remains open.
+
+- [ ] **Step 3: Integrate generations, runner, view factory, and keymap**
+
+Extend `LoopTuiDependencies` with an injectable `renderDialog` factory. For each `openFeedback` call:
+
+```ts
+const generation = ++latestGeneration
+ownedGeneration = generation
+const actions = createLoopDialogActions(model.taskIds)
+const runner = createLoopActionRunner({
+  writeClipboard: dependencies.writeClipboard,
+  notifySuccess,
+  notifyFailure,
+  closeIfCurrent: () => closeGeneration(generation),
+})
+```
+
+Register commands for previous/next action, activate, message page up/down, and close. Bind `up`, `down`, `enter`, `return`, `space`, `pageup`, `pagedown`, and `q`; retain native `Esc`. Render through the injected factory and clear the keyboard ref in `onClose`.
+
+- [ ] **Step 4: Run focused integration tests and verify GREEN**
+
+Run: `npm run build && node --test tests/tui-plugin.test.mjs tests/tui-dialog-actions.test.mjs`
+
+Expected: all focused tests PASS, including failure recovery and replacement race.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui.ts tests/tui-plugin.test.mjs
+git commit -m "feat: close Loop feedback after successful copy"
+```
+
+### Task 5: Documentation, version, and release artifact
+
+**Files:**
+- Modify: `README.md`
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `tests/package-exports.test.mjs`
+
+**Interfaces:**
+- Produces: npm artifact version `0.2.6` with current GitHub/npm README.
+
+- [ ] **Step 1: Add a failing version assertion**
+
+```js
+test("publishes the responsive dialog release", () => {
+  assert.equal(packageJson.version, "0.2.6")
+})
+```
+
+- [ ] **Step 2: Verify the assertion is RED**
+
+Run: `node --test tests/package-exports.test.mjs`
+
+Expected: FAIL with actual version `0.2.5`.
+
+- [ ] **Step 3: Bump version and update README**
+
+Run: `npm version 0.2.6 --no-git-tag-version`
+
+Document that successful copy closes the dialog, failed copy stays open, and short terminals use independently scrollable message/action regions. Change pinned installation examples from `0.2.5` to `0.2.6`.
+
+- [ ] **Step 4: Run the full automated gate**
+
+Run: `npm test && npm publish --dry-run && git diff --check`
+
+Expected: all tests PASS; dry-run contains `dist/tui-dialog-view.js`, responsive helper modules, README, and version `0.2.6`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md package.json package-lock.json tests/package-exports.test.mjs
+git commit -m "docs: prepare responsive Loop dialog release"
+```
+
+### Task 6: Review and real OpenCode resize verification
+
+**Files:**
+- No production file changes unless verification exposes a defect.
+
+- [ ] **Step 1: Run final static and automated checks from a clean tree**
+
+Run:
+
+```bash
+npm ci
+npm test
+npm publish --dry-run
+git diff --check
+git status --short
+```
+
+Expected: 0 failures, valid 0.2.6 tarball, and no tracked changes.
+
+- [ ] **Step 2: Install the branch into an isolated OpenCode config**
+
+Run `opencode plugin file:///absolute/path/to/worktree --global --force` with isolated `XDG_CONFIG_HOME` and `XDG_CACHE_HOME`, then copy `commands/loop.md` into the isolated OpenCode commands directory.
+
+Expected: installer reports `Detected server + tui targets`.
+
+- [ ] **Step 3: Verify normal and narrow PTYs**
+
+Start OpenCode 1.17.18 after `stty rows 30 cols 100`, run `/loop 1m responsive verification`, and verify full message, `Copy ID`, `Copy all`, and `Close`. Resize the active PTY with `stty rows 16 cols 58`; verify the dialog stays within the viewport, both regions scroll, the selected action stays visible, and the prompt remains unobstructed.
+
+- [ ] **Step 4: Verify copy semantics**
+
+Select `Copy ID` and confirm the exact stored ID is in the clipboard and the dialog closes. Reopen with `/loop list`, select `Copy all`, confirm exact message equality and automatic close. Inject or simulate clipboard failure and verify the dialog remains open with an error toast.
+
+- [ ] **Step 5: Request code review and address findings**
+
+Review the complete range from `a6c5989` to the implementation HEAD, with emphasis on OpenTUI dependency identity, responsive overflow, async generation races, cleanup, and server-only import isolation.
+
+- [ ] **Step 6: Run the verification-before-completion gate**
+
+Repeat `npm test`, `npm publish --dry-run`, `git diff --check`, `git status --short`, and the focused real OpenCode scenario after any review fixes. Do not push or publish until all fresh evidence passes.

--- a/docs/superpowers/specs/2026-07-15-responsive-loop-dialog-design.md
+++ b/docs/superpowers/specs/2026-07-15-responsive-loop-dialog-design.md
@@ -1,0 +1,122 @@
+# Responsive Loop dialog design
+
+## Context
+
+Version 0.2.5 moved `/loop` feedback out of raw terminal output and into an OpenCode `DialogSelect`. That fixes prompt corruption, but it places the complete Loop message inside the select component's title. OpenCode constrains the option list height, not the wrapped title height. A long message can therefore consume most or all of a short terminal and push the actions outside the visible area.
+
+The current copy actions also leave the dialog open after a successful clipboard write. The requested behavior is to close immediately after `Copy ID` or `Copy all` succeeds.
+
+## Goals
+
+- Keep the complete Loop result available inside the dialog.
+- Make the dialog respond to terminal width and height changes without overflowing the viewport.
+- Keep every action reachable in short or narrow terminals.
+- Close the current dialog immediately after a successful copy.
+- Keep the dialog open after a clipboard failure so the user can retry or close it.
+- Preserve keyboard, mouse, replacement, cleanup, and structured-error behavior from 0.2.5.
+
+## Non-goals
+
+- Scaling terminal font size. Terminal UIs render in character cells and cannot resize the user's font.
+- Replacing OpenCode's native dialog stack or backdrop.
+- Changing scheduler behavior, task persistence, or `/loop` command syntax.
+- Truncating the value copied by `Copy all`.
+
+## Chosen approach
+
+Render a custom OpenCode TUI JSX component inside the native `api.ui.dialog` stack. The component uses the supported `@opentui/solid` and `@opentui/core` primitives, while OpenCode continues to own modal focus, backdrop behavior, `Esc`, theme integration, and dialog replacement.
+
+The alternatives were rejected for these reasons:
+
+- Keeping `DialogSelect` would still leave the full message in a non-scrollable title, so it cannot satisfy the small-window requirement without truncation.
+- A plugin-owned full-screen overlay would allow arbitrary percentages but would duplicate OpenCode's modal focus and dialog lifecycle, increasing compatibility risk.
+
+## Layout
+
+The host dialog remains `medium`. OpenCode therefore uses a nominal width of 60 columns and clamps it to the terminal width minus two columns. This makes the width shrink automatically in narrow windows while retaining the native margins and backdrop.
+
+The custom content calculates its maximum height from live terminal dimensions:
+
+1. Start with 70% of the terminal row count.
+2. Cap the result at 28 rows for large terminals.
+3. Clamp it to the rows available inside OpenCode's dialog margins.
+4. On extremely short terminals, use all available rows instead of enforcing a minimum that could overflow.
+
+The component contains three regions:
+
+1. A fixed header with the variant icon, `Loop`, and an `esc` hint.
+2. A scrollable message viewport containing the exact Loop result.
+3. A bottom action viewport containing one `Copy ID` action per distinct ID, followed by `Copy all` and `Close`.
+
+The action viewport shows at least the selected row whenever any row can be displayed. With many task IDs it scrolls independently instead of expanding the dialog. The message viewport receives the remaining height. On extremely short terminals, actions take priority and the message remains available through a one-row scroll viewport and `Copy all`.
+
+Terminal resize signals cause the height allocation to recompute without closing or recreating the dialog.
+
+## Interaction model
+
+- `Up` and `Down` move through actions and keep the selected action visible.
+- `Enter` and `Space` activate the selected action.
+- Mouse click selects and activates an action.
+- Mouse wheel scrolls the region under the pointer.
+- `PageUp` and `PageDown` scroll the message viewport.
+- `q` and OpenCode's native `Esc` close the dialog.
+- A new Loop result replaces the old dialog and resets selection to the first action.
+
+Copy behavior is transactional:
+
+1. Ignore repeated activation while the selected copy is in progress.
+2. Await the clipboard write.
+3. On success, show the existing success toast and close the dialog only if it is still the same dialog generation.
+4. On failure, show the existing error toast and keep that dialog open.
+
+The generation check prevents a slow clipboard operation from closing a newer Loop result that replaced the original dialog.
+
+## Component boundaries
+
+### Feedback model
+
+`src/tui-feedback-model.ts` continues to own exact message preservation, task ID extraction, deduplication, and toast ownership checks.
+
+### Dialog controller
+
+A small controller owns the ordered actions, selected index, copy-in-progress guard, generation identity, and action execution. It contains no JSX so selection and async copy behavior can be tested independently.
+
+### Dialog view
+
+The TUI JSX view owns responsive row allocation, theme-aware rendering, two scroll viewports, selected-row visibility, and mouse/keyboard presentation. It delegates actions to the controller.
+
+### Plugin lifecycle
+
+`src/tui.tsx` continues to subscribe to `tui.toast.show`, replace owned dialogs, register the temporary keymap layer, clean up on close/disposal, and write structured diagnostics for render or registration failures.
+
+## Dependencies and packaging
+
+- Compile the TUI entrypoint as TSX with `@opentui/solid` as the JSX import source.
+- Add compatible OpenTUI packages as development dependencies for compilation and peer dependencies for the OpenCode host runtime, following the OpenCode 1.17.18 TUI plugin contract.
+- Keep the server entrypoint free of OpenTUI and clipboard imports.
+- Preserve the published root, `./server`, and `./tui` entrypoints.
+
+## Error handling
+
+- Clipboard failure keeps the current dialog open and produces an error toast.
+- Dialog construction, keymap registration, or cleanup failures cannot escape the event handler.
+- Partial ownership is cleared and the temporary keymap layer is released after an opening failure.
+- Structured warnings use `api.client.app.log`; no direct terminal output is introduced.
+- Disposal clears only the dialog generation owned by this plugin.
+
+## Testing
+
+Automated tests cover:
+
+- successful `Copy ID` closes the current dialog after writing the exact ID;
+- successful `Copy all` closes after writing the exact complete message;
+- clipboard failure leaves the dialog open;
+- a slow copy from an old generation cannot close its replacement;
+- duplicate activation is ignored while copying;
+- action ordering and selection wrapping;
+- responsive height allocation for normal, short, and extremely short terminals;
+- long messages and up to 50 task IDs remain reachable through independent scrolling;
+- keyboard, mouse, `q`, and native close cleanup;
+- existing render/keymap failure recovery and the full server regression suite.
+
+Manual verification uses OpenCode 1.17.18 in both a normal PTY and a deliberately narrow/short PTY. It confirms dynamic resize, message scrolling, action scrolling, exact clipboard values, automatic close on success, and no content written over the prompt.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-plugin-loop",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "clipboardy": "4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,10 @@
       },
       "devDependencies": {
         "@opencode-ai/plugin": "^1.17.18",
+        "@opentui/core": "0.4.3",
+        "@opentui/solid": "0.4.3",
         "@types/node": "^22.0.0",
+        "solid-js": "1.9.12",
         "typescript": "^5.4.0"
       },
       "engines": {
@@ -21,7 +24,10 @@
         "opencode": ">=1.17.18"
       },
       "peerDependencies": {
-        "@opencode-ai/plugin": ">=1.17.18"
+        "@opencode-ai/plugin": ">=1.17.18",
+        "@opentui/core": ">=0.4.3",
+        "@opentui/solid": ">=0.4.3",
+        "solid-js": "1.9.12"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -35,6 +41,492 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.6",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -160,6 +652,164 @@
         "cross-spawn": "7.0.6"
       }
     },
+    "node_modules/@opentui/core": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.4.3.tgz",
+      "integrity": "sha512-rrJfAk13tALDqldYjhc78eWQ+aKq1iknJgffIOg3OwyZoqQo+p6gtuqyhmWvXIfQzlNUbpgpCPcxbXlhMnlaHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-ffi-structs": "0.2.4",
+        "diff": "9.0.0",
+        "marked": "17.0.1",
+        "string-width": "7.2.0",
+        "strip-ansi": "7.1.2"
+      },
+      "optionalDependencies": {
+        "@opentui/core-darwin-arm64": "0.4.3",
+        "@opentui/core-darwin-x64": "0.4.3",
+        "@opentui/core-linux-arm64": "0.4.3",
+        "@opentui/core-linux-arm64-musl": "0.4.3",
+        "@opentui/core-linux-x64": "0.4.3",
+        "@opentui/core-linux-x64-musl": "0.4.3",
+        "@opentui/core-win32-arm64": "0.4.3",
+        "@opentui/core-win32-x64": "0.4.3"
+      },
+      "peerDependencies": {
+        "web-tree-sitter": "0.25.10"
+      }
+    },
+    "node_modules/@opentui/core-darwin-arm64": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-arm64/-/core-darwin-arm64-0.4.3.tgz",
+      "integrity": "sha512-p5+7AAxpxGuDGagyQfewKtmTFnN7THvTVY4FyKqUtJomNaHdQXPHztapNNzMx0DGWbwOUbVKzpL+yc3CZY3chQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opentui/core-darwin-x64": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-darwin-x64/-/core-darwin-x64-0.4.3.tgz",
+      "integrity": "sha512-+fh0vEUE0lwVC7RW5ijYLRlTLp5NfvCRj8SzxDVd7IL2j2ssB6YXcfIbXq2EW7UGnrejwPRXf1tgUrIXW9KmOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@opentui/core-linux-arm64": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64/-/core-linux-arm64-0.4.3.tgz",
+      "integrity": "sha512-gl6qA5QJy6u8Cbt7gOtHbhhfMZ4qQDb0kEwFXHcMGmbnKzz4OHoq74D6tNjyvSQB9saoC7C6C0tvn2DcJOuNog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-linux-arm64-musl": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-arm64-musl/-/core-linux-arm64-musl-0.4.3.tgz",
+      "integrity": "sha512-8p8g8/AEq/xFGpQ7XcIFKcAqjc0QwsZcv+Ll9RbCDpUA56FGH6jfLDir0KYTNTgYXJTIrBIENI9K46VuxMUMQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-linux-x64": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64/-/core-linux-x64-0.4.3.tgz",
+      "integrity": "sha512-dXpJitiZdYE3hq2Pvx6e9I0uPQSOcnaLLp1pDgWAHv+3kvKSHEX//9Yr/pV/Ua6qqT7p+2D/K4vXNap/NKVo2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-linux-x64-musl": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-linux-x64-musl/-/core-linux-x64-musl-0.4.3.tgz",
+      "integrity": "sha512-/QiFpCrpU2O7vy8QYmLIQYbvAtKDgmqcVjR7dGtqSzkiQk3ktNJoo5RozG7ueXnjung1Wp0nKldKxo2Csg/OrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@opentui/core-win32-arm64": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-arm64/-/core-win32-arm64-0.4.3.tgz",
+      "integrity": "sha512-Mx2zuOjrhm/z2SDS6RExIyjP/SnN/8QhhagxURUw0jQi/NssGSeAllu1cBAFFnhobJL5QLTE4FU4CRhUK9svgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opentui/core-win32-x64": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@opentui/core-win32-x64/-/core-win32-x64-0.4.3.tgz",
+      "integrity": "sha512-NuoqvWKGXaYnmlqvu7Gg2lLI6yVMnS9OfWBvxp+7Q+McSgHFSTQmYBXaPpvQ8HikpQXE1nCeMPtuSG4PdZHe2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opentui/solid": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@opentui/solid/-/solid-0.4.3.tgz",
+      "integrity": "sha512-RcV0+S8HMdXOASyr7HmJUBuTUIaFPzAxMDa44VftS5C2JUgrmAuWo0Njv1q3TWRB1owjHnyKhEfWGKq7A82wxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "7.28.0",
+        "@babel/preset-typescript": "7.27.1",
+        "@opentui/core": "0.4.3",
+        "babel-plugin-module-resolver": "5.0.2",
+        "babel-preset-solid": "1.9.12",
+        "entities": "7.0.1",
+        "s-js": "^0.4.9"
+      },
+      "peerDependencies": {
+        "solid-js": "1.9.12"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -176,6 +826,177 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/babel-plugin-jsx-dom-expressions": {
+      "version": "0.40.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.40.7.tgz",
+      "integrity": "sha512-/O6JWUmjv03OI9lL2ry9bUjpD5S3PclM55RRJEyCdcFZ5W2SEA/59d+l2hNsk3gI6kiWRdRPdOtqZmsQzFN1pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "7.18.6",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.20.7",
+        "html-entities": "2.3.3",
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.20.12"
+      }
+    },
+    "node_modules/babel-plugin-jsx-dom-expressions/node_modules/@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
+      "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-babel-config": "^2.1.1",
+        "glob": "^9.3.3",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.1.7",
+        "resolve": "^1.22.8"
+      }
+    },
+    "node_modules/babel-preset-solid": {
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.12.tgz",
+      "integrity": "sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jsx-dom-expressions": "^0.40.6"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "solid-js": "^1.9.12"
+      },
+      "peerDependenciesMeta": {
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bun-ffi-structs": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/bun-ffi-structs/-/bun-ffi-structs-0.2.4.tgz",
+      "integrity": "sha512-AJzsqoVFs1KBbJbWHIYrVZLDC3NhTqqh25awRXqzoLzmBAKr5oqk6+CwuYHAekKx+VBCYVohBoKuRq40dV+TYg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/clipboardy": {
       "version": "4.0.0",
@@ -194,6 +1015,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -208,6 +1036,31 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -217,6 +1070,16 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/effect": {
@@ -236,6 +1099,53 @@
         "toml": "^4.1.1",
         "uuid": "^14.0.0",
         "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.392",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
+      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/execa": {
@@ -284,12 +1194,75 @@
         "node": ">=12.17.0"
       }
     },
+    "node_modules/find-babel-config": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz",
+      "integrity": "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.3"
+      }
+    },
     "node_modules/find-my-way-ts": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
       "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/get-stream": {
       "version": "8.0.1",
@@ -302,6 +1275,46 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "5.0.0",
@@ -320,6 +1333,22 @@
       "license": "ISC",
       "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-docker": {
@@ -403,6 +1432,26 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -410,12 +1459,62 @@
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/kubernetes-types": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
       "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -434,6 +1533,39 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/minimatch": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+      "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/msgpackr": {
       "version": "2.0.4",
@@ -491,6 +1623,16 @@
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -533,11 +1675,147 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -558,6 +1836,75 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/s-js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/s-js/-/s-js-0.4.9.tgz",
+      "integrity": "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/seroval": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.5.tgz",
+      "integrity": "sha512-bSjOuPcwPKLSJNhr9+bZxA20nQxVle5J5MNsYRVE6cIg7KpRLXGupymePavu0jrxlPiPsr4xGZSB8yUY2sH2sw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.5.tgz",
+      "integrity": "sha512-+BDhqYM6CEn3x09v44dpa9p6974FuUB2dxk+Ctn04k0cO1Zt6QODTXfmEZK0eBaTe/fJBvP4NMGuNJ+R8T+QMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -592,6 +1939,52 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/solid-js": {
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.12.tgz",
+      "integrity": "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.0",
+        "seroval": "~1.5.0",
+        "seroval-plugins": "~1.5.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -602,6 +1995,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/system-architecture": {
@@ -647,6 +2053,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
@@ -659,6 +2096,22 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/emscripten": "^1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/emscripten": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {
@@ -675,6 +2128,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "/loop command for opencode — run prompts on a schedule (fixed, adaptive, or maintenance), modeled after Claude Code's /loop",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -61,11 +61,17 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "@opencode-ai/plugin": ">=1.17.18"
+    "@opencode-ai/plugin": ">=1.17.18",
+    "@opentui/core": ">=0.4.3",
+    "@opentui/solid": ">=0.4.3",
+    "solid-js": "1.9.12"
   },
   "devDependencies": {
     "@opencode-ai/plugin": "^1.17.18",
+    "@opentui/core": "0.4.3",
+    "@opentui/solid": "0.4.3",
     "@types/node": "^22.0.0",
+    "solid-js": "1.9.12",
     "typescript": "^5.4.0"
   },
   "opencode": {

--- a/src/tui-dialog-actions.ts
+++ b/src/tui-dialog-actions.ts
@@ -1,0 +1,54 @@
+export type LoopDialogAction =
+  | { type: "copy-id"; taskId: string }
+  | { type: "copy-all" }
+  | { type: "close" }
+
+export function createLoopDialogActions(
+  taskIds: readonly string[]
+): readonly LoopDialogAction[] {
+  return [
+    ...taskIds.map((taskId) => ({ type: "copy-id" as const, taskId })),
+    { type: "copy-all" as const },
+    { type: "close" as const },
+  ]
+}
+
+export interface LoopActionRunnerDependencies {
+  writeClipboard(text: string): Promise<void>
+  notifySuccess(description: string): void
+  notifyFailure(): void
+  closeIfCurrent(): void
+}
+
+export function createLoopActionRunner(input: LoopActionRunnerDependencies) {
+  let busy = false
+
+  return {
+    get busy() {
+      return busy
+    },
+
+    async run(action: LoopDialogAction, message: string): Promise<void> {
+      if (action.type === "close") {
+        input.closeIfCurrent()
+        return
+      }
+      if (busy) return
+
+      busy = true
+      const text = action.type === "copy-all" ? message : action.taskId
+      const description =
+        action.type === "copy-all" ? "Loop result" : `Task ID ${action.taskId}`
+
+      try {
+        await input.writeClipboard(text)
+        input.notifySuccess(description)
+        input.closeIfCurrent()
+      } catch {
+        input.notifyFailure()
+      } finally {
+        busy = false
+      }
+    },
+  }
+}

--- a/src/tui-dialog-layout.ts
+++ b/src/tui-dialog-layout.ts
@@ -1,0 +1,39 @@
+export interface LoopDialogRows {
+  maxHeight: number
+  messageRows: number
+  actionRows: number
+}
+
+export function allocateLoopDialogRows(
+  terminalRows: number,
+  actionCount: number
+): LoopDialogRows {
+  const rows = Math.max(1, Math.floor(terminalRows))
+  const available = Math.max(1, rows - 4)
+  const maxHeight = Math.min(28, available, Math.max(6, Math.floor(rows * 0.7)))
+  const contentRows = Math.max(0, maxHeight - 3)
+
+  if (contentRows < 2) {
+    return { maxHeight, messageRows: 0, actionRows: contentRows }
+  }
+
+  const actionRows = Math.min(
+    Math.max(0, actionCount),
+    Math.max(1, Math.min(6, Math.floor(contentRows * 0.4)))
+  )
+
+  return {
+    maxHeight,
+    messageRows: contentRows - actionRows,
+    actionRows,
+  }
+}
+
+export function moveLoopActionIndex(
+  current: number,
+  delta: number,
+  count: number
+): number {
+  if (count <= 0) return 0
+  return ((current + delta) % count + count) % count
+}

--- a/src/tui-dialog-view.tsx
+++ b/src/tui-dialog-view.tsx
@@ -96,10 +96,14 @@ export function LoopFeedbackDialog(props: LoopFeedbackDialogProps): JSX.Element 
 
   return (
     <box
+      width="100%"
+      height={rows().maxHeight}
+      minHeight={rows().maxHeight}
       maxHeight={rows().maxHeight}
       flexDirection="column"
+      flexShrink={0}
       gap={1}
-      paddingBottom={1}
+      overflow="hidden"
     >
       <box
         paddingLeft={3}
@@ -117,7 +121,10 @@ export function LoopFeedbackDialog(props: LoopFeedbackDialogProps): JSX.Element 
       <Show when={rows().messageRows > 0}>
         <scrollbox
           ref={(value: ScrollBoxRenderable) => (messageScroll = value)}
+          height={rows().messageRows}
+          minHeight={rows().messageRows}
           maxHeight={rows().messageRows}
+          flexShrink={0}
           paddingLeft={3}
           paddingRight={3}
           scrollbarOptions={{ visible: true }}
@@ -129,7 +136,10 @@ export function LoopFeedbackDialog(props: LoopFeedbackDialogProps): JSX.Element 
       <Show when={rows().actionRows > 0}>
         <scrollbox
           ref={(value: ScrollBoxRenderable) => (actionScroll = value)}
+          height={rows().actionRows}
+          minHeight={rows().actionRows}
           maxHeight={rows().actionRows}
+          flexShrink={0}
           paddingLeft={1}
           paddingRight={1}
           scrollbarOptions={{ visible: false }}

--- a/src/tui-dialog-view.tsx
+++ b/src/tui-dialog-view.tsx
@@ -1,0 +1,179 @@
+/** @jsxImportSource @opentui/solid */
+import { RGBA, TextAttributes, type ScrollBoxRenderable } from "@opentui/core"
+import { useTerminalDimensions, type JSX } from "@opentui/solid"
+import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import type { TuiThemeCurrent } from "@opencode-ai/plugin/tui"
+
+import type { LoopDialogAction } from "./tui-dialog-actions.js"
+import {
+  allocateLoopDialogRows,
+  moveLoopActionIndex,
+} from "./tui-dialog-layout.js"
+
+export interface LoopFeedbackDialogRef {
+  move(delta: number): void
+  activate(): void
+  pageMessage(delta: number): void
+  dispose(): void
+}
+
+export interface LoopFeedbackDialogProps {
+  message: string
+  variant: "info" | "success" | "warning" | "error"
+  actions: readonly LoopDialogAction[]
+  theme: TuiThemeCurrent
+  onActivate(action: LoopDialogAction): void | Promise<void>
+  ref?(value: LoopFeedbackDialogRef | undefined): void
+}
+
+const transparent = RGBA.fromInts(0, 0, 0, 0)
+
+function label(action: LoopDialogAction): string {
+  if (action.type === "copy-id") return `Copy ID: ${action.taskId}`
+  if (action.type === "copy-all") return "Copy all"
+  return "Close"
+}
+
+function description(action: LoopDialogAction): string {
+  if (action.type === "copy-id") return "Copy this task ID"
+  if (action.type === "copy-all") return "Copy the complete Loop result"
+  return "Close this Loop result"
+}
+
+export function LoopFeedbackDialog(props: LoopFeedbackDialogProps): JSX.Element {
+  const dimensions = useTerminalDimensions()
+  const [selected, setSelected] = createSignal(0)
+  const rows = createMemo(() =>
+    allocateLoopDialogRows(dimensions().height, props.actions.length)
+  )
+  let messageScroll: ScrollBoxRenderable | undefined
+  let actionScroll: ScrollBoxRenderable | undefined
+
+  const keepSelectedVisible = () => {
+    const scroll = actionScroll
+    const target = scroll?.getChildren()[selected()]
+    if (!scroll || !target) return
+
+    const offset = target.y - scroll.y
+    if (offset < 0) scroll.scrollBy(offset)
+    if (offset >= scroll.height) scroll.scrollBy(offset - scroll.height + 1)
+  }
+
+  const controller: LoopFeedbackDialogRef = {
+    move(delta) {
+      setSelected((index) =>
+        moveLoopActionIndex(index, delta, props.actions.length)
+      )
+    },
+    activate() {
+      const action = props.actions[selected()]
+      if (action) void props.onActivate(action)
+    },
+    pageMessage(delta) {
+      if (!messageScroll) return
+      messageScroll.scrollBy(delta * Math.max(1, messageScroll.height - 1))
+    },
+    dispose() {
+      messageScroll = undefined
+      actionScroll = undefined
+    },
+  }
+
+  props.ref?.(controller)
+  createEffect(() => {
+    selected()
+    queueMicrotask(keepSelectedVisible)
+  })
+  onCleanup(() => {
+    controller.dispose()
+    props.ref?.(undefined)
+  })
+
+  const icon = () =>
+    ({ info: "ℹ", success: "✓", warning: "⚠", error: "✕" })[
+      props.variant
+    ]
+
+  return (
+    <box
+      maxHeight={rows().maxHeight}
+      flexDirection="column"
+      gap={1}
+      paddingBottom={1}
+    >
+      <box
+        paddingLeft={3}
+        paddingRight={3}
+        flexDirection="row"
+        justifyContent="space-between"
+        flexShrink={0}
+      >
+        <text fg={props.theme.text} attributes={TextAttributes.BOLD}>
+          {icon()} Loop
+        </text>
+        <text fg={props.theme.textMuted}>esc</text>
+      </box>
+
+      <Show when={rows().messageRows > 0}>
+        <scrollbox
+          ref={(value: ScrollBoxRenderable) => (messageScroll = value)}
+          maxHeight={rows().messageRows}
+          paddingLeft={3}
+          paddingRight={3}
+          scrollbarOptions={{ visible: true }}
+        >
+          <text fg={props.theme.text}>{props.message}</text>
+        </scrollbox>
+      </Show>
+
+      <Show when={rows().actionRows > 0}>
+        <scrollbox
+          ref={(value: ScrollBoxRenderable) => (actionScroll = value)}
+          maxHeight={rows().actionRows}
+          paddingLeft={1}
+          paddingRight={1}
+          scrollbarOptions={{ visible: false }}
+        >
+          <For each={props.actions}>
+            {(action, index) => {
+              const active = () => selected() === index()
+              return (
+                <box
+                  paddingLeft={2}
+                  paddingRight={2}
+                  flexDirection="row"
+                  gap={1}
+                  backgroundColor={
+                    active() ? props.theme.primary : transparent
+                  }
+                  onMouseDown={() => setSelected(index())}
+                  onMouseUp={() => void props.onActivate(action)}
+                >
+                  <text
+                    fg={
+                      active()
+                        ? props.theme.selectedListItemText
+                        : props.theme.text
+                    }
+                    attributes={active() ? TextAttributes.BOLD : undefined}
+                  >
+                    {label(action)}
+                  </text>
+                  <text
+                    fg={
+                      active()
+                        ? props.theme.selectedListItemText
+                        : props.theme.textMuted
+                    }
+                  >
+                    {description(action)}
+                  </text>
+                </box>
+              )
+            }}
+          </For>
+        </scrollbox>
+      </Show>
+    </box>
+  )
+}

--- a/src/tui-dialog-view.tsx
+++ b/src/tui-dialog-view.tsx
@@ -149,6 +149,11 @@ export function LoopFeedbackDialog(props: LoopFeedbackDialogProps): JSX.Element 
               const active = () => selected() === index()
               return (
                 <box
+                  height={1}
+                  minHeight={1}
+                  maxHeight={1}
+                  flexShrink={0}
+                  overflow="hidden"
                   paddingLeft={2}
                   paddingRight={2}
                   flexDirection="row"
@@ -160,6 +165,9 @@ export function LoopFeedbackDialog(props: LoopFeedbackDialogProps): JSX.Element 
                   onMouseUp={() => void props.onActivate(action)}
                 >
                   <text
+                    wrapMode="none"
+                    truncate={true}
+                    flexShrink={0}
                     fg={
                       active()
                         ? props.theme.selectedListItemText
@@ -170,6 +178,9 @@ export function LoopFeedbackDialog(props: LoopFeedbackDialogProps): JSX.Element 
                     {label(action)}
                   </text>
                   <text
+                    wrapMode="none"
+                    truncate={true}
+                    flexShrink={1}
                     fg={
                       active()
                         ? props.theme.selectedListItemText

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -1,10 +1,21 @@
 import type {
-  TuiDialogSelectOption,
   TuiPlugin,
+  TuiPluginApi,
   TuiPluginModule,
 } from "@opencode-ai/plugin/tui"
+import type { JSX } from "@opentui/solid"
 import clipboardy from "clipboardy"
 
+import {
+  createLoopActionRunner,
+  createLoopDialogActions,
+  type LoopDialogAction,
+} from "./tui-dialog-actions.js"
+import {
+  LoopFeedbackDialog,
+  type LoopFeedbackDialogProps,
+  type LoopFeedbackDialogRef,
+} from "./tui-dialog-view.js"
 import {
   LOOP_COPY_TITLE,
   createLoopFeedbackModel,
@@ -12,24 +23,45 @@ import {
   type LoopFeedbackInput,
 } from "./tui-feedback-model.js"
 
-type LoopDialogAction =
-  | { type: "copy-id"; taskId: string }
-  | { type: "copy-all" }
-  | { type: "close" }
+export interface LoopDialogRenderInput extends LoopFeedbackDialogProps {
+  api: TuiPluginApi
+  close(): void
+}
 
 export interface LoopTuiDependencies {
   writeClipboard(text: string): Promise<void>
+  renderDialog?(input: LoopDialogRenderInput): JSX.Element
 }
 
-const defaultDependencies: LoopTuiDependencies = {
+const defaultDependencies: Required<LoopTuiDependencies> = {
   writeClipboard: (text) => clipboardy.write(text),
+  renderDialog(input) {
+    return input.api.ui.Dialog({
+      onClose: input.close,
+      children: LoopFeedbackDialog({
+        message: input.message,
+        variant: input.variant,
+        actions: input.actions,
+        theme: input.theme,
+        onActivate: input.onActivate,
+        ref: input.ref,
+      }),
+    })
+  },
 }
 
 export function createLoopTuiPlugin(
-  dependencies: LoopTuiDependencies = defaultDependencies
+  input: LoopTuiDependencies = defaultDependencies
 ): TuiPlugin {
+  const dependencies: Required<LoopTuiDependencies> = {
+    ...defaultDependencies,
+    ...input,
+  }
+
   return async (api) => {
-    let ownsDialog = false
+    let latestGeneration = 0
+    let ownedGeneration: number | undefined
+    let dialogRef: LoopFeedbackDialogRef | undefined
     let unregisterCloseLayer: (() => void) | undefined
 
     const releaseCloseLayer = () => {
@@ -40,6 +72,28 @@ export function createLoopTuiPlugin(
       } catch {
         // Cleanup must not interrupt later Loop feedback or TUI disposal.
       }
+    }
+
+    const finishGeneration = (generation: number) => {
+      if (ownedGeneration !== generation) return
+      ownedGeneration = undefined
+      dialogRef?.dispose()
+      dialogRef = undefined
+      releaseCloseLayer()
+    }
+
+    const closeGeneration = (generation: number) => {
+      if (ownedGeneration !== generation) return
+      try {
+        api.ui.dialog.clear()
+      } finally {
+        finishGeneration(generation)
+      }
+    }
+
+    const close = () => {
+      const generation = ownedGeneration
+      if (generation !== undefined) closeGeneration(generation)
     }
 
     const logDialogFailure = (error: unknown) => {
@@ -58,39 +112,74 @@ export function createLoopTuiPlugin(
       }
     }
 
-    const close = () => {
-      if (ownsDialog) api.ui.dialog.clear()
+    const notifySuccess = (description: string) => {
+      api.ui.toast({
+        title: LOOP_COPY_TITLE,
+        message: `${description} copied to clipboard.`,
+        variant: "success",
+        duration: 2500,
+      })
     }
 
-    const copy = async (text: string, description: string) => {
-      try {
-        await dependencies.writeClipboard(text)
-        api.ui.toast({
-          title: LOOP_COPY_TITLE,
-          message: `${description} copied to clipboard.`,
-          variant: "success",
-          duration: 2500,
-        })
-      } catch {
-        api.ui.toast({
-          title: LOOP_COPY_TITLE,
-          message: "Could not copy to the system clipboard.",
-          variant: "error",
-          duration: 4000,
-        })
-      }
+    const notifyFailure = () => {
+      api.ui.toast({
+        title: LOOP_COPY_TITLE,
+        message: "Could not copy to the system clipboard.",
+        variant: "error",
+        duration: 4000,
+      })
     }
 
-    const openFeedback = (input: LoopFeedbackInput) => {
-      try {
-        const model = createLoopFeedbackModel(input)
+    const openFeedback = (feedback: LoopFeedbackInput) => {
+      const generation = ++latestGeneration
 
-        if (ownsDialog) api.ui.dialog.clear()
+      try {
+        const model = createLoopFeedbackModel(feedback)
+
+        if (ownedGeneration !== undefined) closeGeneration(ownedGeneration)
         releaseCloseLayer()
+
+        const actions = createLoopDialogActions(model.taskIds)
+        const runner = createLoopActionRunner({
+          writeClipboard: dependencies.writeClipboard,
+          notifySuccess,
+          notifyFailure,
+          closeIfCurrent: () => closeGeneration(generation),
+        })
 
         unregisterCloseLayer = api.keymap.registerLayer({
           priority: 1000,
           commands: [
+            {
+              name: "loop.dialog.previous",
+              title: "Previous Loop action",
+              category: "Loop",
+              run: () => dialogRef?.move(-1),
+            },
+            {
+              name: "loop.dialog.next",
+              title: "Next Loop action",
+              category: "Loop",
+              run: () => dialogRef?.move(1),
+            },
+            {
+              name: "loop.dialog.activate",
+              title: "Activate Loop action",
+              category: "Loop",
+              run: () => dialogRef?.activate(),
+            },
+            {
+              name: "loop.dialog.page-up",
+              title: "Scroll Loop message up",
+              category: "Loop",
+              run: () => dialogRef?.pageMessage(-1),
+            },
+            {
+              name: "loop.dialog.page-down",
+              title: "Scroll Loop message down",
+              category: "Loop",
+              run: () => dialogRef?.pageMessage(1),
+            },
             {
               name: "loop.dialog.close",
               title: "Close Loop feedback",
@@ -99,74 +188,48 @@ export function createLoopTuiPlugin(
             },
           ],
           bindings: [
-            {
-              key: "q",
-              cmd: "loop.dialog.close",
-              desc: "Close Loop feedback",
-            },
+            { key: "up", cmd: "loop.dialog.previous", desc: "Previous action" },
+            { key: "down", cmd: "loop.dialog.next", desc: "Next action" },
+            { key: "enter", cmd: "loop.dialog.activate", desc: "Activate action" },
+            { key: "return", cmd: "loop.dialog.activate", desc: "Activate action" },
+            { key: "space", cmd: "loop.dialog.activate", desc: "Activate action" },
+            { key: "pageup", cmd: "loop.dialog.page-up", desc: "Scroll message up" },
+            { key: "pagedown", cmd: "loop.dialog.page-down", desc: "Scroll message down" },
+            { key: "q", cmd: "loop.dialog.close", desc: "Close Loop feedback" },
           ],
         })
 
-        const options: TuiDialogSelectOption<LoopDialogAction>[] = [
-          ...model.taskIds.map((taskId) => ({
-            title: `Copy ID: ${taskId}`,
-            description: "Copy this task ID",
-            value: { type: "copy-id" as const, taskId },
-          })),
-          {
-            title: "Copy all",
-            description: "Copy the complete Loop result",
-            value: { type: "copy-all" },
-          },
-          {
-            title: "Close",
-            description: "Close this Loop result",
-            value: { type: "close" },
-          },
-        ]
-
-        const status = {
-          info: "ℹ",
-          success: "✓",
-          warning: "⚠",
-          error: "✕",
-        }[model.variant]
-
-        ownsDialog = true
+        ownedGeneration = generation
+        api.ui.dialog.setSize("medium")
         api.ui.dialog.replace(
           () =>
-            api.ui.DialogSelect<LoopDialogAction>({
-              title: `${status} Loop\n\n${model.message}`,
-              options,
-              skipFilter: true,
-              onSelect(option) {
-                const action = option.value
-                if (action.type === "close") {
-                  close()
-                  return
-                }
-                if (action.type === "copy-all") {
-                  void copy(model.message, "Loop result")
-                  return
-                }
-                void copy(action.taskId, `Task ID ${action.taskId}`)
+            dependencies.renderDialog({
+              api,
+              message: model.message,
+              variant: model.variant,
+              actions,
+              theme: api.theme.current,
+              onActivate(action: LoopDialogAction) {
+                void runner.run(action, model.message)
               },
+              ref(value) {
+                if (ownedGeneration === generation) dialogRef = value
+              },
+              close: () => closeGeneration(generation),
             }),
-          () => {
-            ownsDialog = false
-            releaseCloseLayer()
-          }
+          () => finishGeneration(generation)
         )
       } catch (error) {
-        if (ownsDialog) {
+        if (ownedGeneration === generation) {
           try {
             api.ui.dialog.clear()
           } catch {
             // Continue with local state cleanup and structured diagnostics.
           }
+          finishGeneration(generation)
+        } else {
+          releaseCloseLayer()
         }
-        ownsDialog = false
-        releaseCloseLayer()
         logDialogFailure(error)
       }
     }
@@ -178,7 +241,7 @@ export function createLoopTuiPlugin(
 
     api.lifecycle.onDispose(() => {
       unsubscribe()
-      if (ownsDialog) api.ui.dialog.clear()
+      close()
       releaseCloseLayer()
     })
   }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -36,16 +36,13 @@ export interface LoopTuiDependencies {
 const defaultDependencies: Required<LoopTuiDependencies> = {
   writeClipboard: (text) => clipboardy.write(text),
   renderDialog(input) {
-    return input.api.ui.Dialog({
-      onClose: input.close,
-      children: LoopFeedbackDialog({
-        message: input.message,
-        variant: input.variant,
-        actions: input.actions,
-        theme: input.theme,
-        onActivate: input.onActivate,
-        ref: input.ref,
-      }),
+    return LoopFeedbackDialog({
+      message: input.message,
+      variant: input.variant,
+      actions: input.actions,
+      theme: input.theme,
+      onActivate: input.onActivate,
+      ref: input.ref,
     })
   },
 }

--- a/tests/package-exports.test.mjs
+++ b/tests/package-exports.test.mjs
@@ -6,6 +6,10 @@ const packageJson = JSON.parse(
   await readFile(new URL("../package.json", import.meta.url), "utf8"),
 )
 
+test("publishes the responsive dialog release", () => {
+  assert.equal(packageJson.version, "0.2.6")
+})
+
 test("publishes explicit server and TUI plugin entrypoints", () => {
   assert.deepEqual(packageJson.exports["./server"], {
     types: "./dist/index.d.ts",

--- a/tests/package-exports.test.mjs
+++ b/tests/package-exports.test.mjs
@@ -33,6 +33,12 @@ test("pins the clipboard runtime used by the published TUI companion", () => {
   assert.equal(packageJson.dependencies.clipboardy, "4.0.0")
 })
 
+test("declares the host TUI peers used by the responsive dialog", () => {
+  assert.equal(packageJson.peerDependencies["@opentui/core"], ">=0.4.3")
+  assert.equal(packageJson.peerDependencies["@opentui/solid"], ">=0.4.3")
+  assert.equal(packageJson.peerDependencies["solid-js"], "1.9.12")
+})
+
 test("test command always builds fresh output before running tests", () => {
   assert.match(packageJson.scripts.test, /^npm run build && /)
 })

--- a/tests/tui-dialog-actions.test.mjs
+++ b/tests/tui-dialog-actions.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  createLoopActionRunner,
+  createLoopDialogActions,
+} from "../dist/tui-dialog-actions.js"
+
+test("orders task copies before Copy all and Close", () => {
+  assert.deepEqual(createLoopDialogActions(["abc123", "def456"]), [
+    { type: "copy-id", taskId: "abc123" },
+    { type: "copy-id", taskId: "def456" },
+    { type: "copy-all" },
+    { type: "close" },
+  ])
+})
+
+test("successful copies close only their current generation", async () => {
+  const copied = []
+  let current = true
+  let closes = 0
+  const runner = createLoopActionRunner({
+    writeClipboard: async (text) => copied.push(text),
+    notifySuccess() {},
+    notifyFailure() {},
+    closeIfCurrent: () => {
+      if (current) closes++
+    },
+  })
+
+  await runner.run({ type: "copy-id", taskId: "abc123" }, "full message")
+  assert.deepEqual(copied, ["abc123"])
+  assert.equal(closes, 1)
+
+  current = false
+  await runner.run({ type: "copy-all" }, "full message")
+  assert.deepEqual(copied, ["abc123", "full message"])
+  assert.equal(closes, 1)
+})
+
+test("clipboard failure keeps the dialog open", async () => {
+  let failures = 0
+  let closes = 0
+  const runner = createLoopActionRunner({
+    writeClipboard: async () => {
+      throw new Error("denied")
+    },
+    notifySuccess() {},
+    notifyFailure: () => failures++,
+    closeIfCurrent: () => closes++,
+  })
+
+  await runner.run({ type: "copy-all" }, "exact")
+  assert.equal(failures, 1)
+  assert.equal(closes, 0)
+  assert.equal(runner.busy, false)
+})
+
+test("duplicate activation is ignored while copying", async () => {
+  let release
+  let writes = 0
+  const runner = createLoopActionRunner({
+    writeClipboard: () =>
+      new Promise((resolve) => {
+        writes++
+        release = resolve
+      }),
+    notifySuccess() {},
+    notifyFailure() {},
+    closeIfCurrent() {},
+  })
+
+  const first = runner.run({ type: "copy-all" }, "exact")
+  const second = runner.run({ type: "copy-all" }, "exact")
+  assert.equal(writes, 1)
+  assert.equal(runner.busy, true)
+  release()
+  await Promise.all([first, second])
+  assert.equal(runner.busy, false)
+})
+
+test("Close bypasses clipboard and closes immediately", async () => {
+  let writes = 0
+  let closes = 0
+  const runner = createLoopActionRunner({
+    writeClipboard: async () => writes++,
+    notifySuccess() {},
+    notifyFailure() {},
+    closeIfCurrent: () => closes++,
+  })
+
+  await runner.run({ type: "close" }, "message")
+  assert.equal(writes, 0)
+  assert.equal(closes, 1)
+})

--- a/tests/tui-dialog-layout.test.mjs
+++ b/tests/tui-dialog-layout.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  allocateLoopDialogRows,
+  moveLoopActionIndex,
+} from "../dist/tui-dialog-layout.js"
+
+test("allocates a capped 70-percent dialog with independent viewports", () => {
+  assert.deepEqual(allocateLoopDialogRows(24, 3), {
+    maxHeight: 16,
+    messageRows: 10,
+    actionRows: 3,
+  })
+  assert.deepEqual(allocateLoopDialogRows(80, 52), {
+    maxHeight: 28,
+    messageRows: 19,
+    actionRows: 6,
+  })
+})
+
+test("never allocates beyond an extremely short terminal", () => {
+  assert.deepEqual(allocateLoopDialogRows(7, 3), {
+    maxHeight: 3,
+    messageRows: 0,
+    actionRows: 0,
+  })
+})
+
+test("action selection wraps in both directions", () => {
+  assert.equal(moveLoopActionIndex(0, -1, 3), 2)
+  assert.equal(moveLoopActionIndex(2, 1, 3), 0)
+  assert.equal(moveLoopActionIndex(4, 2, 0), 0)
+})

--- a/tests/tui-plugin.test.mjs
+++ b/tests/tui-plugin.test.mjs
@@ -57,6 +57,7 @@ function createFakeApi() {
         toasts.push(input)
       },
     },
+    theme: { current: {} },
     keymap: {
       registerLayer(layer) {
         const record = { layer, active: true }
@@ -102,11 +103,25 @@ function emitLoop(api, message, variant = "info") {
   })
 }
 
+function createTestLoopTuiPlugin(dependencies = {}) {
+  return createLoopTuiPlugin({
+    writeClipboard: async () => {},
+    renderDialog(props) {
+      return props
+    },
+    ...dependencies,
+  })
+}
+
 function select(api, title) {
   const view = api.__view()
-  const option = view.options.find((candidate) => candidate.title === title)
-  assert.ok(option, `missing dialog option: ${title}`)
-  view.onSelect(option)
+  const action = view.actions.find((candidate) => {
+    if (candidate.type === "copy-id") return `Copy ID: ${candidate.taskId}` === title
+    if (candidate.type === "copy-all") return title === "Copy all"
+    return title === "Close"
+  })
+  assert.ok(action, `missing dialog action: ${title}`)
+  view.onActivate(action)
 }
 
 const settle = () => new Promise((resolve) => setImmediate(resolve))
@@ -119,39 +134,46 @@ test("exports a TUI-only OpenCode plugin module", () => {
 
 test("shows variant-aware status treatment in the dialog title", async () => {
   const api = createFakeApi()
-  await createLoopTuiPlugin({ writeClipboard: async () => {} })(api)
+  await createTestLoopTuiPlugin()(api)
 
   emitLoop(api, "Created", "success")
-  assert.match(api.__view().title, /^✓ Loop/)
+  assert.equal(api.__view().variant, "success")
   emitLoop(api, "Failed", "error")
-  assert.match(api.__view().title, /^✕ Loop/)
+  assert.equal(api.__view().variant, "error")
 })
 
 test("opens one native dialog with per-task copy actions", async () => {
   const api = createFakeApi()
   const copied = []
-  await createLoopTuiPlugin({ writeClipboard: async (text) => copied.push(text) })(api)
+  await createTestLoopTuiPlugin({
+    writeClipboard: async (text) => copied.push(text),
+  })(api)
 
   emitLoop(api, "[first01] active\n[second2] paused")
 
   assert.equal(api.ui.dialog.open, true)
   assert.equal(api.ui.dialog.depth, 1)
-  assert.match(api.__view().title, /\[first01\] active/)
+  assert.match(api.__view().message, /\[first01\] active/)
   assert.deepEqual(
-    api.__view().options.map((option) => option.title),
+    api.__view().actions.map((action) =>
+      action.type === "copy-id" ? `Copy ID: ${action.taskId}` : action.type === "copy-all" ? "Copy all" : "Close"
+    ),
     ["Copy ID: first01", "Copy ID: second2", "Copy all", "Close"],
   )
 
   select(api, "Copy ID: second2")
   await settle()
   assert.deepEqual(copied, ["second2"])
-  assert.equal(api.ui.dialog.open, true)
+  assert.equal(api.ui.dialog.open, false)
+  assert.equal(api.__layers.filter((layer) => layer.active).length, 0)
 })
 
 test("copies the exact complete feedback text", async () => {
   const api = createFakeApi()
   const copied = []
-  await createLoopTuiPlugin({ writeClipboard: async (text) => copied.push(text) })(api)
+  await createTestLoopTuiPlugin({
+    writeClipboard: async (text) => copied.push(text),
+  })(api)
   const message = "Loop started [id=abc123]\nCancel: /loop cancel abc123"
 
   emitLoop(api, message, "success")
@@ -160,12 +182,13 @@ test("copies the exact complete feedback text", async () => {
 
   assert.deepEqual(copied, [message])
   assert.equal(api.__toasts.at(-1).title, LOOP_COPY_TITLE)
-  assert.equal(api.ui.dialog.open, true)
+  assert.equal(api.ui.dialog.open, false)
+  assert.equal(api.__layers.filter((layer) => layer.active).length, 0)
 })
 
 test("keeps the dialog open and reports clipboard errors without recursion", async () => {
   const api = createFakeApi()
-  await createLoopTuiPlugin({
+  await createTestLoopTuiPlugin({
     writeClipboard: async () => {
       throw new Error("clipboard unavailable")
     },
@@ -183,21 +206,21 @@ test("keeps the dialog open and reports clipboard errors without recursion", asy
 
 test("replaces prior Loop feedback instead of stacking dialogs", async () => {
   const api = createFakeApi()
-  await createLoopTuiPlugin({ writeClipboard: async () => {} })(api)
+  await createTestLoopTuiPlugin()(api)
 
   emitLoop(api, "Loop started [id=first01]", "success")
   const firstLayer = api.__layers.at(-1)
   emitLoop(api, "Loop started [id=second2]", "success")
 
   assert.equal(api.ui.dialog.depth, 1)
-  assert.match(api.__view().title, /second2/)
+  assert.match(api.__view().message, /second2/)
   assert.equal(firstLayer.active, false)
   assert.equal(api.__layers.filter((layer) => layer.active).length, 1)
 })
 
 test("closes from the action or temporary q shortcut", async () => {
   const api = createFakeApi()
-  await createLoopTuiPlugin({ writeClipboard: async () => {} })(api)
+  await createTestLoopTuiPlugin()(api)
 
   emitLoop(api, "No loop tasks found")
   select(api, "Close")
@@ -206,13 +229,75 @@ test("closes from the action or temporary q shortcut", async () => {
 
   emitLoop(api, "No loop tasks found")
   const layer = api.__layers.findLast((candidate) => candidate.active).layer
-  layer.commands[0].run()
+  layer.commands.find((command) => command.name === "loop.dialog.close").run()
   assert.equal(api.ui.dialog.open, false)
+})
+
+test("keyboard commands drive the responsive view and Enter closes after copy", async () => {
+  const api = createFakeApi()
+  const copied = []
+  const pageDeltas = []
+  let selected = 0
+  await createTestLoopTuiPlugin({
+    writeClipboard: async (text) => copied.push(text),
+    renderDialog(props) {
+      props.ref({
+        move(delta) {
+          selected = (selected + delta + props.actions.length) % props.actions.length
+        },
+        activate() {
+          props.onActivate(props.actions[selected])
+        },
+        pageMessage(delta) {
+          pageDeltas.push(delta)
+        },
+        dispose() {},
+      })
+      return props
+    },
+  })(api)
+
+  emitLoop(api, "Loop started [id=abc123]", "success")
+  const layer = api.__layers.findLast((candidate) => candidate.active).layer
+  const run = (name) => layer.commands.find((command) => command.name === name).run()
+  assert.deepEqual(
+    layer.bindings.map((binding) => binding.key),
+    ["up", "down", "enter", "return", "space", "pageup", "pagedown", "q"],
+  )
+
+  run("loop.dialog.next")
+  run("loop.dialog.page-down")
+  run("loop.dialog.activate")
+  await settle()
+
+  assert.deepEqual(pageDeltas, [1])
+  assert.deepEqual(copied, ["Loop started [id=abc123]"])
+  assert.equal(api.ui.dialog.open, false)
+})
+
+test("a slow copy from a replaced dialog cannot close the current dialog", async () => {
+  const api = createFakeApi()
+  let resolveCopy
+  await createTestLoopTuiPlugin({
+    writeClipboard: () => new Promise((resolve) => {
+      resolveCopy = resolve
+    }),
+  })(api)
+
+  emitLoop(api, "Loop started [id=first01]", "success")
+  select(api, "Copy ID: first01")
+  emitLoop(api, "Loop started [id=second2]", "success")
+  assert.match(api.__view().message, /second2/)
+
+  resolveCopy()
+  await settle()
+  assert.equal(api.ui.dialog.open, true)
+  assert.match(api.__view().message, /second2/)
 })
 
 test("ignores unrelated toasts and cleans up all owned state on disposal", async () => {
   const api = createFakeApi()
-  await createLoopTuiPlugin({ writeClipboard: async () => {} })(api)
+  await createTestLoopTuiPlugin()(api)
 
   api.__emit("tui.toast.show", {
     type: "tui.toast.show",
@@ -231,13 +316,13 @@ test("ignores unrelated toasts and cleans up all owned state on disposal", async
 
 test("cleans up and logs when dialog rendering fails, then recovers", async () => {
   const api = createFakeApi()
-  const render = api.ui.DialogSelect
   let failRender = true
-  api.ui.DialogSelect = (props) => {
-    if (failRender) throw new Error("render failed")
-    return render(props)
-  }
-  await createLoopTuiPlugin({ writeClipboard: async () => {} })(api)
+  await createTestLoopTuiPlugin({
+    renderDialog(props) {
+      if (failRender) throw new Error("render failed")
+      return props
+    },
+  })(api)
 
   assert.doesNotThrow(() => emitLoop(api, "First [id=first01]", "success"))
   await settle()
@@ -251,7 +336,7 @@ test("cleans up and logs when dialog rendering fails, then recovers", async () =
   failRender = false
   emitLoop(api, "Second [id=second2]", "success")
   assert.equal(api.ui.dialog.open, true)
-  assert.match(api.__view().title, /second2/)
+  assert.match(api.__view().message, /second2/)
 })
 
 test("does not leak state when close-layer registration fails", async () => {
@@ -262,7 +347,7 @@ test("does not leak state when close-layer registration fails", async () => {
     if (failRegistration) throw new Error("keymap failed")
     return registerLayer(layer)
   }
-  await createLoopTuiPlugin({ writeClipboard: async () => {} })(api)
+  await createTestLoopTuiPlugin()(api)
 
   assert.doesNotThrow(() => emitLoop(api, "First [id=first01]", "success"))
   await settle()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
     "declarationMap": false,
     "sourceMap": false,
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@opentui/solid"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
## Summary

- close the Loop dialog after successful Copy ID or Copy all actions while keeping it open on clipboard failure
- render Loop feedback with responsive, independently scrollable message and action regions
- keep actions single-line on narrow terminals and guard async copies from closing a replacement dialog
- update package metadata and README for the 0.2.6 release

## Testing

- npm test — 116/116 passing
- npm publish --dry-run
- real OpenCode 1.17.18 verification at 100x30, 58x16, and 40x14
- verified Copy ID and Copy all clipboard contents and automatic close behavior
