### PR TITLE
Fix Loop dialog keyboard and mouse navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A drop-in `/loop` command for [opencode](https://opencode.ai), modeled after Cla
 - **LLM-callable tools** — `loop_schedule`, `loop_status` (session-bound by default)
 - **Interactive Loop results** — `/loop` results open in a dedicated native dialog instead of writing over the prompt
 - **Clipboard actions** — copy the complete result or copy any displayed task ID with one action
+- **Keyboard and mouse navigation** — move with `Up`/`Down` or `Tab`/`Shift+Tab`, hover with the pointer, and activate with `Enter`, `Space`, or a click
 - **Responsive layout** — short or narrow terminals keep the dialog inside the viewport with independently scrollable result and action areas
 - **Easy dismissal** — choose **Close**, press `q`, or use the native dialog's `Esc` key
 
@@ -147,7 +148,7 @@ Every `/loop` command result opens in a separate native OpenCode dialog. It keep
 - **Copy all** for the exact complete result text
 - **Close** to dismiss the dialog
 
-Use the mouse or arrow keys to select an action, then press `Enter` or `Space`. A successful **Copy ID** or **Copy all** action shows a confirmation and closes the dialog immediately; if clipboard access fails, the dialog stays open and shows an error. Press `Page Up` or `Page Down` to scroll long result text, or press `q` or `Esc` to close. In short or narrow terminals, the dialog scales to the available viewport and keeps the result and action lists independently scrollable. A newer Loop result replaces the previous Loop dialog rather than stacking another one.
+Use `Up`/`Down` or `Tab`/`Shift+Tab` to change the selected action, then press `Enter` or `Space` to activate it. Moving the mouse over a row selects it, and clicking activates that exact row. A successful **Copy ID** or **Copy all** action shows a confirmation and closes the dialog immediately; if clipboard access fails, the dialog stays open and shows an error. Press `Page Up` or `Page Down` to scroll long result text, or press `q` or `Esc` to close. In short or narrow terminals, the dialog scales to the available viewport and keeps the result and action lists independently scrollable. A newer Loop result replaces the previous Loop dialog rather than stacking another one.
 
 ### Programmatic (LLM tools)
 
@@ -213,9 +214,9 @@ Tasks persist to `.opencode/cache/loop/tasks.json` (per project). Fire history i
 
 ## Troubleshooting
 
-### Package entrypoints in 0.2.6
+### Package entrypoints
 
-Version 0.2.6 exposes separate `opencode-plugin-loop/server` and `opencode-plugin-loop/tui` entrypoints so OpenCode can load the scheduler and responsive interactive dialog independently. The root export remains the v1-compatible server module for backward compatibility. Programmatic consumers should use the named factory:
+Current releases expose separate `opencode-plugin-loop/server` and `opencode-plugin-loop/tui` entrypoints so OpenCode can load the scheduler and responsive interactive dialog independently. The root export remains the v1-compatible server module for backward compatibility. Programmatic consumers should use the named factory:
 
 ```typescript
 import { LoopPlugin } from "opencode-plugin-loop"
@@ -223,7 +224,7 @@ import { LoopPlugin } from "opencode-plugin-loop"
 
 ### Task lines overlap the input area
 
-Versions before 0.2.4 wrote `/loop` results directly to the terminal. OpenCode owns and redraws the terminal UI, so those writes could leave task IDs and prompts over the input area. Upgrade to 0.2.6 for the responsive interactive dialog; runtime diagnostics go to OpenCode's structured application log.
+Older releases wrote `/loop` results directly to the terminal. OpenCode owns and redraws the terminal UI, so those writes could leave task IDs and prompts over the input area. Upgrade to the current release for the responsive interactive dialog; runtime diagnostics go to OpenCode's structured application log.
 
 Also make sure the plugin is installed from only one source. OpenCode loads npm plugins from `opencode.json` and copied plugins under `~/.config/opencode/plugins/` independently, even when they have the same package name.
 

--- a/docs/superpowers/plans/2026-07-16-loop-dialog-navigation.md
+++ b/docs/superpowers/plans/2026-07-16-loop-dialog-navigation.md
@@ -1,0 +1,125 @@
+# Loop Dialog Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every Loop dialog action selectable and activatable with real keyboard and mouse input, then release the verified fix as 0.2.8.
+
+**Architecture:** The mounted Solid dialog owns keyboard input through `useKeyboard`, while pure helper functions translate key and pointer events into controller operations. `src/tui.ts` keeps dialog generation and clipboard ownership but no longer creates a competing plugin-level keymap layer.
+
+**Tech Stack:** TypeScript, Node.js test runner, SolidJS 1.9.12, OpenCode TUI API 1.17.18, OpenTUI 0.4.3, npm.
+
+## Global Constraints
+
+- OpenCode minimum version remains `>=1.17.18`.
+- `Copy ID` and `Copy all` close only after a successful clipboard write.
+- Clipboard failure keeps the current dialog open.
+- The native OpenCode dialog stack continues to own `Esc`, backdrop, and modal focus.
+- Runtime code writes no text directly to stdout or stderr.
+- Existing Loop tasks on the user's machine are not changed by validation.
+- Root, `./server`, and `./tui` exports remain compatible.
+
+---
+
+## File structure
+
+- Create `src/tui-dialog-interaction.ts`: pure keyboard and pointer event translation.
+- Create `tests/tui-dialog-interaction.test.mjs`: regression coverage for real handler behavior.
+- Modify `src/tui-dialog-view.tsx`: mounted keyboard listener and hover/click row wiring.
+- Modify `src/tui.ts`: remove the temporary keymap layer and pass close ownership to the view.
+- Modify `tests/tui-plugin.test.mjs`: assert the simplified lifecycle and generation behavior.
+- Modify `package.json` and `package-lock.json`: release version 0.2.8.
+- Modify `README.md`: document keyboard and mouse controls.
+
+### Task 1: Interaction regression helpers
+
+**Files:**
+- Create: `src/tui-dialog-interaction.ts`
+- Create: `tests/tui-dialog-interaction.test.mjs`
+
+**Interfaces:**
+- Produces: `handleLoopDialogKey(event, controller): boolean`.
+- Produces: `createLoopDialogPointerHandlers(index, controller)`.
+- Consumes controller methods `move`, `select`, `activate`, `activateAt`, `pageMessage`, and `close`.
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests that import the two helpers, send `up`, `down`, `tab`, shifted `tab`, `return`, `space`, `pageup`, `pagedown`, and `q`, and assert the exact controller call plus `preventDefault`/`stopPropagation`. Add a pointer test that asserts hover and press select the row and release activates the same row.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `npm run build && node --test tests/tui-dialog-interaction.test.mjs`
+
+Expected: FAIL because `dist/tui-dialog-interaction.js` does not exist.
+
+- [ ] **Step 3: Implement the minimal pure helpers**
+
+Implement a switch over `event.name`, use `event.shift` for reverse tab, consume only recognized keys, and return pointer callbacks that close over the row index.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `npm run build && node --test tests/tui-dialog-interaction.test.mjs`
+
+Expected: all interaction tests PASS.
+
+### Task 2: Mount input handling in the dialog
+
+**Files:**
+- Modify: `src/tui-dialog-view.tsx`
+- Modify: `src/tui.ts`
+- Modify: `tests/tui-plugin.test.mjs`
+
+**Interfaces:**
+- `LoopFeedbackDialogProps` gains `onClose(): void` and no longer exposes an external ref.
+- The internal controller implements the interaction helper contract.
+
+- [ ] **Step 1: Write failing plugin lifecycle assertions**
+
+Update the plugin test to require zero temporary keymap layers after opening and to close through the view callback. Run it before production edits and confirm it fails because 0.2.7 registers a layer.
+
+- [ ] **Step 2: Wire `useKeyboard` and pointer helpers**
+
+Create the controller inside `LoopFeedbackDialog`, call `useKeyboard` with `handleLoopDialogKey`, use the pointer callbacks on every action row, and keep selection visibility behavior unchanged.
+
+- [ ] **Step 3: Remove plugin-level keyboard layer state**
+
+Delete registration, disposal, and failure cleanup for the temporary layer. Pass `onClose` to the rendered view while retaining generation checks.
+
+- [ ] **Step 4: Verify focused and full suites**
+
+Run: `npm run build && node --test tests/tui-dialog-interaction.test.mjs tests/tui-plugin.test.mjs`
+
+Then run: `npm test`
+
+Expected: all tests PASS with zero failures.
+
+### Task 3: Release and end-to-end verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `package.json`
+- Modify: `package-lock.json`
+
+**Interfaces:**
+- Produces npm package version `0.2.8` with unchanged exports.
+
+- [ ] **Step 1: Document controls and bump version**
+
+Document `Up/Down`, `Tab/Shift+Tab`, `Enter/Space`, mouse hover/click, `q`, and `Esc`. Update package metadata to 0.2.8.
+
+- [ ] **Step 2: Verify package contents**
+
+Run: `npm test && npm publish --dry-run`
+
+Expected: full suite passes and dry-run contains the required dist, command, README, license, and package metadata files.
+
+- [ ] **Step 3: Validate in local OpenCode**
+
+Install the packed build into the actual OpenCode plugin cache without changing existing task state. Open `/loop list --all` in a separate OpenCode process and verify keyboard movement/activation, mouse hover/click, and close behavior.
+
+- [ ] **Step 4: Commit, push, and integrate**
+
+Review the complete diff, commit only scoped files, push `codex/fix-loop-dialog-navigation`, create a ready pull request, and merge after checks pass.
+
+- [ ] **Step 5: Publish and revalidate**
+
+Run authenticated `npm publish`, confirm `npm view opencode-plugin-loop version` is 0.2.8, refresh the local OpenCode cache from npm, and rerun the smoke test.

--- a/docs/superpowers/specs/2026-07-16-loop-dialog-navigation-design.md
+++ b/docs/superpowers/specs/2026-07-16-loop-dialog-navigation-design.md
@@ -1,0 +1,53 @@
+# Loop dialog navigation design
+
+## Context
+
+The 0.2.7 Loop dialog renders the actions correctly, but its interaction wiring does not follow the lifecycle used by OpenCode's own modal components. Keyboard navigation is registered in a plugin-level keymap layer and is only tested by invoking command callbacks directly. Mouse rows react to press and release but not hover. As a result, real terminal input can remain with the host prompt/modal stack, and moving the pointer over another row does not change the selected action.
+
+## Goals
+
+- Let users select `Copy ID`, `Copy all`, and `Close` with `Up`, `Down`, `Tab`, or `Shift+Tab`.
+- Activate the selected action with `Enter` or `Space`.
+- Select rows on mouse hover or press and activate the clicked row on release.
+- Preserve `PageUp`, `PageDown`, `q`, native `Esc`, responsive layout, copy-close behavior, and generation-safe cleanup.
+- Add regression tests that exercise the same handlers used by the rendered component.
+
+## Non-goals
+
+- Changing scheduler, task storage, or `/loop` syntax.
+- Replacing the responsive custom dialog with `DialogSelect`.
+- Changing clipboard contents or copy notifications.
+- Stopping or editing existing Loop tasks on the user's machine.
+
+## Chosen approach
+
+Move keyboard ownership into the mounted `LoopFeedbackDialog` by using `useKeyboard`, matching OpenCode 1.17.18's native dialog components. The listener exists only while the dialog component is mounted and consumes recognized navigation/activation events before they reach the prompt. Remove the separate plugin-level keymap layer and its lifecycle state.
+
+Expose small pure interaction helpers used by the component:
+
+- `handleLoopDialogKey` maps terminal key events to move, activate, page, and close controller operations.
+- `createLoopDialogPointerHandlers` maps hover, press, and release to selection and activation.
+
+This provides deterministic Node tests without requiring OpenTUI's native test renderer, which is unavailable under the repository's Node runtime on this machine.
+
+## Interaction details
+
+- `Up` moves to the previous action and wraps.
+- `Down` moves to the next action and wraps.
+- `Tab` moves forward; `Shift+Tab` moves backward.
+- `Enter`/`Return` and `Space` activate the selected action.
+- `PageUp`/`PageDown` scroll the message viewport.
+- `q` requests dialog close; OpenCode continues to own `Esc`.
+- Mouse hover and mouse-down select the row under the pointer.
+- Mouse-up activates that exact row, so a stale keyboard selection cannot trigger a different action.
+- Recognized keyboard events call `preventDefault` and `stopPropagation`.
+
+## Lifecycle and error handling
+
+The plugin continues to own a single dialog generation. Clipboard completion closes only the generation that initiated it. Replacing or disposing a dialog destroys the component listener automatically. Clipboard failures leave the dialog open. Dialog rendering failures are logged structurally and do not leak owned state.
+
+## Testing and release
+
+Automated tests will first fail against 0.2.7 for the missing key and pointer helpers. They will then cover all key mappings, event consumption, exact-row pointer activation, plugin cleanup without a temporary keymap layer, clipboard behavior, and the full existing suite.
+
+Manual validation will install the packed build into OpenCode's actual plugin cache, open `/loop list --all`, and verify keyboard selection, mouse selection/click, copy-close, and `Close`. After GitHub integration, publish npm version 0.2.8, update the local cache from the published package, and repeat the OpenCode smoke test.

--- a/docs/superpowers/specs/2026-07-16-loop-dialog-navigation-design.md
+++ b/docs/superpowers/specs/2026-07-16-loop-dialog-navigation-design.md
@@ -23,6 +23,8 @@ The 0.2.7 Loop dialog renders the actions correctly, but its interaction wiring 
 
 Move keyboard ownership into the mounted `LoopFeedbackDialog` by using `useKeyboard`, matching OpenCode 1.17.18's native dialog components. The listener exists only while the dialog component is mounted and consumes recognized navigation/activation events before they reach the prompt. Remove the separate plugin-level keymap layer and its lifecycle state.
 
+Arm the mounted listener in the next microtask. This prevents the `Enter`/`Return` event that submitted `/loop` and opened the dialog from immediately activating the initially selected copy action, while keeping subsequent input component-owned.
+
 Expose small pure interaction helpers used by the component:
 
 - `handleLoopDialogKey` maps terminal key events to move, activate, page, and close controller operations.
@@ -41,6 +43,7 @@ This provides deterministic Node tests without requiring OpenTUI's native test r
 - Mouse hover and mouse-down select the row under the pointer.
 - Mouse-up activates that exact row, so a stale keyboard selection cannot trigger a different action.
 - Recognized keyboard events call `preventDefault` and `stopPropagation`.
+- Keyboard input is ignored until the post-mount microtask arms the listener.
 
 ## Lifecycle and error handling
 
@@ -48,6 +51,6 @@ The plugin continues to own a single dialog generation. Clipboard completion clo
 
 ## Testing and release
 
-Automated tests will first fail against 0.2.7 for the missing key and pointer helpers. They will then cover all key mappings, event consumption, exact-row pointer activation, plugin cleanup without a temporary keymap layer, clipboard behavior, and the full existing suite.
+Automated tests will first fail against 0.2.7 for the missing key and pointer helpers. They will then cover all key mappings, event consumption, the command-submitting-key gate, exact-row pointer activation, plugin cleanup without a temporary keymap layer, clipboard behavior, and the full existing suite.
 
 Manual validation will install the packed build into OpenCode's actual plugin cache, open `/loop list --all`, and verify keyboard selection, mouse selection/click, copy-close, and `Close`. After GitHub integration, publish npm version 0.2.8, update the local cache from the published package, and repeat the OpenCode smoke test.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-plugin-loop",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "clipboardy": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "/loop command for opencode — run prompts on a schedule (fixed, adaptive, or maintenance), modeled after Claude Code's /loop",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/tui-dialog-interaction.ts
+++ b/src/tui-dialog-interaction.ts
@@ -1,0 +1,69 @@
+export interface LoopDialogInteractionController {
+  move(delta: number): void
+  select(index: number): void
+  activate(): void
+  activateAt(index: number): void
+  pageMessage(delta: number): void
+  close(): void
+}
+
+export interface LoopDialogKeyEvent {
+  name: string
+  shift?: boolean
+  preventDefault(): void
+  stopPropagation(): void
+}
+
+export function handleLoopDialogKey(
+  event: LoopDialogKeyEvent,
+  controller: LoopDialogInteractionController,
+  enabled = true
+): boolean {
+  if (!enabled) return false
+
+  let run: (() => void) | undefined
+
+  switch (event.name) {
+    case "up":
+      run = () => controller.move(-1)
+      break
+    case "down":
+      run = () => controller.move(1)
+      break
+    case "tab":
+      run = () => controller.move(event.shift ? -1 : 1)
+      break
+    case "enter":
+    case "return":
+    case "space":
+      run = () => controller.activate()
+      break
+    case "pageup":
+      run = () => controller.pageMessage(-1)
+      break
+    case "pagedown":
+      run = () => controller.pageMessage(1)
+      break
+    case "q":
+      run = () => controller.close()
+      break
+    default:
+      return false
+  }
+
+  event.preventDefault()
+  event.stopPropagation()
+  run()
+  return true
+}
+
+export function createLoopDialogPointerHandlers(
+  index: number,
+  controller: LoopDialogInteractionController
+) {
+  return {
+    onMouseOver: () => controller.select(index),
+    onMouseDown: () => controller.select(index),
+    onMouseUp: () => controller.activateAt(index),
+  }
+}

--- a/src/tui-dialog-view.tsx
+++ b/src/tui-dialog-view.tsx
@@ -1,21 +1,19 @@
 /** @jsxImportSource @opentui/solid */
 import { RGBA, TextAttributes, type ScrollBoxRenderable } from "@opentui/core"
-import { useTerminalDimensions, type JSX } from "@opentui/solid"
+import { useKeyboard, useTerminalDimensions, type JSX } from "@opentui/solid"
 import { For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
 import type { TuiThemeCurrent } from "@opencode-ai/plugin/tui"
 
 import type { LoopDialogAction } from "./tui-dialog-actions.js"
 import {
+  createLoopDialogPointerHandlers,
+  handleLoopDialogKey,
+  type LoopDialogInteractionController,
+} from "./tui-dialog-interaction.js"
+import {
   allocateLoopDialogRows,
   moveLoopActionIndex,
 } from "./tui-dialog-layout.js"
-
-export interface LoopFeedbackDialogRef {
-  move(delta: number): void
-  activate(): void
-  pageMessage(delta: number): void
-  dispose(): void
-}
 
 export interface LoopFeedbackDialogProps {
   message: string
@@ -23,7 +21,7 @@ export interface LoopFeedbackDialogProps {
   actions: readonly LoopDialogAction[]
   theme: TuiThemeCurrent
   onActivate(action: LoopDialogAction): void | Promise<void>
-  ref?(value: LoopFeedbackDialogRef | undefined): void
+  onClose(): void
 }
 
 const transparent = RGBA.fromInts(0, 0, 0, 0)
@@ -48,6 +46,8 @@ export function LoopFeedbackDialog(props: LoopFeedbackDialogProps): JSX.Element 
   )
   let messageScroll: ScrollBoxRenderable | undefined
   let actionScroll: ScrollBoxRenderable | undefined
+  let keyboardReady = false
+  let mounted = true
 
   const keepSelectedVisible = () => {
     const scroll = actionScroll
@@ -59,34 +59,50 @@ export function LoopFeedbackDialog(props: LoopFeedbackDialogProps): JSX.Element 
     if (offset >= scroll.height) scroll.scrollBy(offset - scroll.height + 1)
   }
 
-  const controller: LoopFeedbackDialogRef = {
+  const controller: LoopDialogInteractionController = {
     move(delta) {
       setSelected((index) =>
         moveLoopActionIndex(index, delta, props.actions.length)
       )
     },
+    select(index) {
+      if (index < 0 || index >= props.actions.length) return
+      setSelected(index)
+    },
     activate() {
       const action = props.actions[selected()]
       if (action) void props.onActivate(action)
+    },
+    activateAt(index) {
+      const action = props.actions[index]
+      if (!action) return
+      setSelected(index)
+      void props.onActivate(action)
     },
     pageMessage(delta) {
       if (!messageScroll) return
       messageScroll.scrollBy(delta * Math.max(1, messageScroll.height - 1))
     },
-    dispose() {
-      messageScroll = undefined
-      actionScroll = undefined
+    close() {
+      props.onClose()
     },
   }
 
-  props.ref?.(controller)
+  useKeyboard((event) => {
+    handleLoopDialogKey(event, controller, keyboardReady)
+  })
+  queueMicrotask(() => {
+    if (mounted) keyboardReady = true
+  })
   createEffect(() => {
     selected()
     queueMicrotask(keepSelectedVisible)
   })
   onCleanup(() => {
-    controller.dispose()
-    props.ref?.(undefined)
+    mounted = false
+    keyboardReady = false
+    messageScroll = undefined
+    actionScroll = undefined
   })
 
   const icon = () =>
@@ -147,6 +163,10 @@ export function LoopFeedbackDialog(props: LoopFeedbackDialogProps): JSX.Element 
           <For each={props.actions}>
             {(action, index) => {
               const active = () => selected() === index()
+              const pointer = createLoopDialogPointerHandlers(
+                index(),
+                controller
+              )
               return (
                 <box
                   height={1}
@@ -161,8 +181,9 @@ export function LoopFeedbackDialog(props: LoopFeedbackDialogProps): JSX.Element 
                   backgroundColor={
                     active() ? props.theme.primary : transparent
                   }
-                  onMouseDown={() => setSelected(index())}
-                  onMouseUp={() => void props.onActivate(action)}
+                  onMouseOver={pointer.onMouseOver}
+                  onMouseDown={pointer.onMouseDown}
+                  onMouseUp={pointer.onMouseUp}
                 >
                   <text
                     wrapMode="none"

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -14,7 +14,6 @@ import {
 import {
   LoopFeedbackDialog,
   type LoopFeedbackDialogProps,
-  type LoopFeedbackDialogRef,
 } from "./tui-dialog-view.js"
 import {
   LOOP_COPY_TITLE,
@@ -25,7 +24,6 @@ import {
 
 export interface LoopDialogRenderInput extends LoopFeedbackDialogProps {
   api: TuiPluginApi
-  close(): void
 }
 
 export interface LoopTuiDependencies {
@@ -42,7 +40,7 @@ const defaultDependencies: Required<LoopTuiDependencies> = {
       actions: input.actions,
       theme: input.theme,
       onActivate: input.onActivate,
-      ref: input.ref,
+      onClose: input.onClose,
     })
   },
 }
@@ -58,25 +56,10 @@ export function createLoopTuiPlugin(
   return async (api) => {
     let latestGeneration = 0
     let ownedGeneration: number | undefined
-    let dialogRef: LoopFeedbackDialogRef | undefined
-    let unregisterCloseLayer: (() => void) | undefined
-
-    const releaseCloseLayer = () => {
-      const unregister = unregisterCloseLayer
-      unregisterCloseLayer = undefined
-      try {
-        unregister?.()
-      } catch {
-        // Cleanup must not interrupt later Loop feedback or TUI disposal.
-      }
-    }
 
     const finishGeneration = (generation: number) => {
       if (ownedGeneration !== generation) return
       ownedGeneration = undefined
-      dialogRef?.dispose()
-      dialogRef = undefined
-      releaseCloseLayer()
     }
 
     const closeGeneration = (generation: number) => {
@@ -134,7 +117,6 @@ export function createLoopTuiPlugin(
         const model = createLoopFeedbackModel(feedback)
 
         if (ownedGeneration !== undefined) closeGeneration(ownedGeneration)
-        releaseCloseLayer()
 
         const actions = createLoopDialogActions(model.taskIds)
         const runner = createLoopActionRunner({
@@ -142,58 +124,6 @@ export function createLoopTuiPlugin(
           notifySuccess,
           notifyFailure,
           closeIfCurrent: () => closeGeneration(generation),
-        })
-
-        unregisterCloseLayer = api.keymap.registerLayer({
-          priority: 1000,
-          commands: [
-            {
-              name: "loop.dialog.previous",
-              title: "Previous Loop action",
-              category: "Loop",
-              run: () => dialogRef?.move(-1),
-            },
-            {
-              name: "loop.dialog.next",
-              title: "Next Loop action",
-              category: "Loop",
-              run: () => dialogRef?.move(1),
-            },
-            {
-              name: "loop.dialog.activate",
-              title: "Activate Loop action",
-              category: "Loop",
-              run: () => dialogRef?.activate(),
-            },
-            {
-              name: "loop.dialog.page-up",
-              title: "Scroll Loop message up",
-              category: "Loop",
-              run: () => dialogRef?.pageMessage(-1),
-            },
-            {
-              name: "loop.dialog.page-down",
-              title: "Scroll Loop message down",
-              category: "Loop",
-              run: () => dialogRef?.pageMessage(1),
-            },
-            {
-              name: "loop.dialog.close",
-              title: "Close Loop feedback",
-              category: "Loop",
-              run: close,
-            },
-          ],
-          bindings: [
-            { key: "up", cmd: "loop.dialog.previous", desc: "Previous action" },
-            { key: "down", cmd: "loop.dialog.next", desc: "Next action" },
-            { key: "enter", cmd: "loop.dialog.activate", desc: "Activate action" },
-            { key: "return", cmd: "loop.dialog.activate", desc: "Activate action" },
-            { key: "space", cmd: "loop.dialog.activate", desc: "Activate action" },
-            { key: "pageup", cmd: "loop.dialog.page-up", desc: "Scroll message up" },
-            { key: "pagedown", cmd: "loop.dialog.page-down", desc: "Scroll message down" },
-            { key: "q", cmd: "loop.dialog.close", desc: "Close Loop feedback" },
-          ],
         })
 
         ownedGeneration = generation
@@ -209,10 +139,7 @@ export function createLoopTuiPlugin(
               onActivate(action: LoopDialogAction) {
                 void runner.run(action, model.message)
               },
-              ref(value) {
-                if (ownedGeneration === generation) dialogRef = value
-              },
-              close: () => closeGeneration(generation),
+              onClose: () => closeGeneration(generation),
             }),
           () => finishGeneration(generation)
         )
@@ -224,8 +151,6 @@ export function createLoopTuiPlugin(
             // Continue with local state cleanup and structured diagnostics.
           }
           finishGeneration(generation)
-        } else {
-          releaseCloseLayer()
         }
         logDialogFailure(error)
       }
@@ -239,7 +164,6 @@ export function createLoopTuiPlugin(
     api.lifecycle.onDispose(() => {
       unsubscribe()
       close()
-      releaseCloseLayer()
     })
   }
 }

--- a/tests/package-exports.test.mjs
+++ b/tests/package-exports.test.mjs
@@ -6,8 +6,8 @@ const packageJson = JSON.parse(
   await readFile(new URL("../package.json", import.meta.url), "utf8"),
 )
 
-test("publishes the responsive dialog release", () => {
-  assert.equal(packageJson.version, "0.2.7")
+test("publishes the interactive navigation release", () => {
+  assert.equal(packageJson.version, "0.2.8")
 })
 
 test("publishes explicit server and TUI plugin entrypoints", () => {

--- a/tests/tui-dialog-interaction.test.mjs
+++ b/tests/tui-dialog-interaction.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  createLoopDialogPointerHandlers,
+  handleLoopDialogKey,
+} from "../dist/tui-dialog-interaction.js"
+
+function createController() {
+  const calls = []
+  return {
+    calls,
+    controller: {
+      move: (delta) => calls.push(["move", delta]),
+      select: (index) => calls.push(["select", index]),
+      activate: () => calls.push(["activate"]),
+      activateAt: (index) => calls.push(["activateAt", index]),
+      pageMessage: (delta) => calls.push(["pageMessage", delta]),
+      close: () => calls.push(["close"]),
+    },
+  }
+}
+
+function keyEvent(name, options = {}) {
+  const consumed = []
+  return {
+    event: {
+      name,
+      shift: options.shift ?? false,
+      preventDefault: () => consumed.push("preventDefault"),
+      stopPropagation: () => consumed.push("stopPropagation"),
+    },
+    consumed,
+  }
+}
+
+test("maps navigation keys to Loop dialog movement and consumes them", () => {
+  const cases = [
+    ["up", {}, ["move", -1]],
+    ["down", {}, ["move", 1]],
+    ["tab", {}, ["move", 1]],
+    ["tab", { shift: true }, ["move", -1]],
+  ]
+
+  for (const [name, options, expected] of cases) {
+    const { calls, controller } = createController()
+    const { event, consumed } = keyEvent(name, options)
+
+    assert.equal(handleLoopDialogKey(event, controller), true)
+    assert.deepEqual(calls, [expected])
+    assert.deepEqual(consumed, ["preventDefault", "stopPropagation"])
+  }
+})
+
+test("maps activation, paging, and close keys to the selected dialog action", () => {
+  const cases = [
+    ["enter", ["activate"]],
+    ["return", ["activate"]],
+    ["space", ["activate"]],
+    ["pageup", ["pageMessage", -1]],
+    ["pagedown", ["pageMessage", 1]],
+    ["q", ["close"]],
+  ]
+
+  for (const [name, expected] of cases) {
+    const { calls, controller } = createController()
+    const { event, consumed } = keyEvent(name)
+
+    assert.equal(handleLoopDialogKey(event, controller), true)
+    assert.deepEqual(calls, [expected])
+    assert.deepEqual(consumed, ["preventDefault", "stopPropagation"])
+  }
+})
+
+test("leaves unrelated keyboard input available to OpenCode", () => {
+  const { calls, controller } = createController()
+  const { event, consumed } = keyEvent("a")
+
+  assert.equal(handleLoopDialogKey(event, controller), false)
+  assert.deepEqual(calls, [])
+  assert.deepEqual(consumed, [])
+})
+
+test("ignores the command-submitting key until the mounted dialog is armed", () => {
+  const { calls, controller } = createController()
+  const { event, consumed } = keyEvent("return")
+
+  assert.equal(handleLoopDialogKey(event, controller, false), false)
+  assert.deepEqual(calls, [])
+  assert.deepEqual(consumed, [])
+})
+
+test("mouse hover and press select a row while release activates that row", () => {
+  const { calls, controller } = createController()
+  const handlers = createLoopDialogPointerHandlers(2, controller)
+
+  handlers.onMouseOver()
+  handlers.onMouseDown()
+  handlers.onMouseUp()
+
+  assert.deepEqual(calls, [
+    ["select", 2],
+    ["select", 2],
+    ["activateAt", 2],
+  ])
+})

--- a/tests/tui-plugin.test.mjs
+++ b/tests/tui-plugin.test.mjs
@@ -209,16 +209,14 @@ test("replaces prior Loop feedback instead of stacking dialogs", async () => {
   await createTestLoopTuiPlugin()(api)
 
   emitLoop(api, "Loop started [id=first01]", "success")
-  const firstLayer = api.__layers.at(-1)
   emitLoop(api, "Loop started [id=second2]", "success")
 
   assert.equal(api.ui.dialog.depth, 1)
   assert.match(api.__view().message, /second2/)
-  assert.equal(firstLayer.active, false)
-  assert.equal(api.__layers.filter((layer) => layer.active).length, 1)
+  assert.equal(api.__layers.length, 0)
 })
 
-test("closes from the action or temporary q shortcut", async () => {
+test("closes from the action or mounted view callback", async () => {
   const api = createFakeApi()
   await createTestLoopTuiPlugin()(api)
 
@@ -228,51 +226,18 @@ test("closes from the action or temporary q shortcut", async () => {
   assert.equal(api.__layers.filter((layer) => layer.active).length, 0)
 
   emitLoop(api, "No loop tasks found")
-  const layer = api.__layers.findLast((candidate) => candidate.active).layer
-  layer.commands.find((command) => command.name === "loop.dialog.close").run()
+  api.__view().onClose()
   assert.equal(api.ui.dialog.open, false)
 })
 
-test("keyboard commands drive the responsive view and Enter closes after copy", async () => {
+test("mounts dialog interaction without a plugin-level keymap layer", async () => {
   const api = createFakeApi()
-  const copied = []
-  const pageDeltas = []
-  let selected = 0
-  await createTestLoopTuiPlugin({
-    writeClipboard: async (text) => copied.push(text),
-    renderDialog(props) {
-      props.ref({
-        move(delta) {
-          selected = (selected + delta + props.actions.length) % props.actions.length
-        },
-        activate() {
-          props.onActivate(props.actions[selected])
-        },
-        pageMessage(delta) {
-          pageDeltas.push(delta)
-        },
-        dispose() {},
-      })
-      return props
-    },
-  })(api)
+  await createTestLoopTuiPlugin()(api)
 
   emitLoop(api, "Loop started [id=abc123]", "success")
-  const layer = api.__layers.findLast((candidate) => candidate.active).layer
-  const run = (name) => layer.commands.find((command) => command.name === name).run()
-  assert.deepEqual(
-    layer.bindings.map((binding) => binding.key),
-    ["up", "down", "enter", "return", "space", "pageup", "pagedown", "q"],
-  )
-
-  run("loop.dialog.next")
-  run("loop.dialog.page-down")
-  run("loop.dialog.activate")
-  await settle()
-
-  assert.deepEqual(pageDeltas, [1])
-  assert.deepEqual(copied, ["Loop started [id=abc123]"])
-  assert.equal(api.ui.dialog.open, false)
+  assert.equal(api.ui.dialog.open, true)
+  assert.equal(typeof api.__view().onClose, "function")
+  assert.equal(api.__layers.length, 0)
 })
 
 test("a slow copy from a replaced dialog cannot close the current dialog", async () => {
@@ -339,23 +304,14 @@ test("cleans up and logs when dialog rendering fails, then recovers", async () =
   assert.match(api.__view().message, /second2/)
 })
 
-test("does not leak state when close-layer registration fails", async () => {
+test("does not depend on plugin-level keymap registration", async () => {
   const api = createFakeApi()
-  const registerLayer = api.keymap.registerLayer
-  let failRegistration = true
-  api.keymap.registerLayer = (layer) => {
-    if (failRegistration) throw new Error("keymap failed")
-    return registerLayer(layer)
+  api.keymap.registerLayer = () => {
+    throw new Error("plugin-level keymap registration is forbidden")
   }
   await createTestLoopTuiPlugin()(api)
 
-  assert.doesNotThrow(() => emitLoop(api, "First [id=first01]", "success"))
-  await settle()
-  assert.equal(api.ui.dialog.open, false)
-  assert.equal(api.__layers.filter((layer) => layer.active).length, 0)
-  assert.equal(api.__logs.length, 1)
-
-  failRegistration = false
-  emitLoop(api, "Second [id=second2]", "success")
+  emitLoop(api, "Loop started [id=second2]", "success")
   assert.equal(api.ui.dialog.open, true)
+  assert.equal(api.__logs.length, 0)
 })


### PR DESCRIPTION
## Summary
- move Loop dialog keyboard handling into the mounted OpenTUI component
- support Up/Down, Tab/Shift+Tab, Enter/Space, hover, and exact-row click activation
- ignore the command-submitting Enter until the dialog is armed
- remove the plugin-level keymap layer and document navigation
- prepare npm release 0.2.8

## Verification
- npm test (121/121)
- npm publish --dry-run
- packed 0.2.8 installed into the local OpenCode cache
- OpenCode 1.17.18 opened the responsive Loop dialog without auto-copying