### PR TITLE
Fix Loop dialog reactive selection

### DIFF
--- a/docs/superpowers/plans/2026-07-16-loop-dialog-reactivity.md
+++ b/docs/superpowers/plans/2026-07-16-loop-dialog-reactivity.md
@@ -1,0 +1,107 @@
+# Loop dialog reactivity implementation plan
+
+> **Goal:** Restore visible keyboard and pointer selection in the Loop dialog by compiling OpenTUI Solid TSX with the required reactive transform, then verify the packed result in the real local OpenCode TUI.
+
+## Task 1: Add failing build-pipeline regression tests
+
+**Files:**
+
+- Modify: `tests/package-exports.test.mjs`
+- Inspect after build: `dist/tui-dialog-view.js`
+
+1. Add a test that reads `tsconfig.json` and expects `compilerOptions.jsx` to be `preserve`.
+2. Add a test that expects `package.json` to invoke a repository build script rather than raw `tsc` JavaScript emission.
+3. Add a test that reads `dist/tui-dialog-view.js`, rejects `@opentui/solid/jsx-runtime`, and requires Solid-generated reactive update machinery for the selected-row styles.
+4. Run the focused package test with the current build:
+
+   ```bash
+   npm run build && node --test tests/package-exports.test.mjs
+   ```
+
+5. Confirm the new assertions fail for the current `react-jsx`/`tsc` pipeline.
+
+## Task 2: Implement the Solid-aware Node build
+
+**Files:**
+
+- Create: `scripts/build.mjs`
+- Modify: `tsconfig.json`
+- Modify: `package.json`
+- Modify: `package-lock.json`
+
+1. Change TypeScript JSX handling to `preserve`.
+2. Add direct development dependencies on `@babel/core`, `@babel/preset-typescript`, and `babel-preset-solid`.
+3. Add `scripts/build.mjs` that:
+   - removes stale `dist` output;
+   - invokes TypeScript with `--emitDeclarationOnly` for strict checking and declarations;
+   - walks `src` recursively;
+   - strips types from `.ts` and `.tsx` with Babel;
+   - applies Solid universal generation to `.tsx` with module name `@opentui/solid`;
+   - writes matching `.js` paths beneath `dist`;
+   - exits non-zero on any incomplete or failed transform.
+4. Point `npm run build` at `node scripts/build.mjs`; keep `prepare`, `test`, and `prepublishOnly` using the shared build command.
+5. Run the focused regression test and confirm it passes:
+
+   ```bash
+   npm run build && node --test tests/package-exports.test.mjs
+   ```
+
+6. Inspect the built dialog module to confirm that selected-row colors are updated through Solid effects and no JSX runtime import remains.
+7. Commit the build and test changes.
+
+## Task 3: Verify package integrity and existing behavior
+
+**Files:**
+
+- Verify: `dist/**`
+- Verify: packed npm tarball
+
+1. Run the complete test suite:
+
+   ```bash
+   npm test
+   ```
+
+2. Run formatting/diff safety checks:
+
+   ```bash
+   git diff --check
+   ```
+
+3. Pack the package without publishing:
+
+   ```bash
+   npm pack --json --pack-destination /tmp/opencode-loop-reactivity
+   ```
+
+4. Inspect the tarball manifest and files to confirm `dist/tui.js`, `dist/tui-dialog-view.js`, declarations, commands, README, and license are included.
+5. Install/extract the tarball in an isolated temporary project and import the root, server, and TUI entrypoints under the expected host dependencies.
+
+## Task 4: Replace local caches and run a real OpenCode smoke test
+
+**Files/state:**
+
+- Remove and recreate: `~/.cache/opencode/packages/opencode-plugin-loop`
+- Remove and recreate: `~/.cache/opencode/packages/opencode-plugin-loop@latest`
+- Preserve: `~/.config/opencode/opencode.json`
+- Preserve: `~/.config/opencode/tui.json`
+
+1. Record current plugin configuration and confirm it remains unpinned (`opencode-plugin-loop` / `opencode-plugin-loop@latest` as already configured).
+2. Remove both Loop plugin cache wrappers so stale `0.2.8` JavaScript cannot be reused.
+3. Recreate the normal wrapper, install the packed local artifact into it without changing the user's configuration, and verify the installed dialog module has the Solid reactive transform.
+4. Start a fresh OpenCode PTY owned by this task only.
+5. Create or list a Loop task and open the Loop result dialog.
+6. Verify the visible highlight moves through `Copy ID`, `Copy all`, and `Close` with:
+   - `Down` and `Up`;
+   - `Tab` and `Shift+Tab`;
+   - mouse hover/click where the PTY/UI supports pointer injection.
+7. Verify `Enter` activates the selected action and copy actions close the dialog.
+8. Stop only the test-owned OpenCode process, leaving existing user sessions and Loop tasks untouched.
+9. Re-run a clean cache inspection to confirm no diagnostic hooks or old generated JSX remain.
+
+## Task 5: Final review and handoff
+
+1. Review the complete branch diff for scope, generated-code assumptions, and accidental configuration changes.
+2. Run the verification commands again from a clean build.
+3. Report the root cause, changed files, exact automated test results, real OpenCode interaction evidence, and the local cache state.
+4. Do not push GitHub changes or publish npm unless the user explicitly requests those remote mutations.

--- a/docs/superpowers/specs/2026-07-16-loop-dialog-reactivity-design.md
+++ b/docs/superpowers/specs/2026-07-16-loop-dialog-reactivity-design.md
@@ -1,0 +1,66 @@
+# Loop dialog reactivity design
+
+## Context
+
+OpenCode 1.17.18 displays the Loop result dialog and highlights `Copy ID` initially, but pressing `Up`, `Down`, or `Tab` does not visibly move the highlight. Instrumentation in a real local OpenCode process showed that the renderer emits the `down` key, the mounted `LoopFeedbackDialog` receives it, and the selected action signal changes from index `0` to index `1`. The interaction controller is therefore working; the rendered attributes are not reacting to signal changes.
+
+The package currently compiles TSX directly with TypeScript using `jsx: react-jsx`. The resulting `dist/tui-dialog-view.js` evaluates expressions such as `active() ? theme.primary : transparent` once while creating the element. OpenTUI Solid requires preserved JSX followed by the Solid universal transform, which generates subscriptions for reactive attributes. Because that transform is missing, the dialog renders its initial state but freezes its highlight, responsive dimensions, and other signal-backed properties.
+
+## Goals
+
+- Compile OpenTUI Solid TSX with the Solid universal transform.
+- Make keyboard and pointer selection changes visibly update the action highlight.
+- Preserve the existing Node/npm development and publishing workflow.
+- Preserve TypeScript declarations and all current package exports.
+- Add regression coverage that fails if TSX is again emitted through the non-reactive JSX runtime.
+- Validate the packed package in the real local OpenCode TUI.
+
+## Non-goals
+
+- Changing the dialog layout, action labels, keyboard mappings, or copy-close behavior.
+- Replacing the custom responsive dialog with OpenCode's `DialogSelect`.
+- Changing scheduler, task persistence, `/loop` syntax, or OpenCode configuration.
+- Publishing to GitHub or npm as part of this local-fix task unless separately requested.
+
+## Chosen approach
+
+Keep the project on Node and npm, but replace the JavaScript-emission portion of `tsc` with a small Node build script backed by Babel:
+
+1. Set TypeScript JSX handling to `preserve` so TypeScript never lowers TSX through `@opentui/solid/jsx-runtime`.
+2. Run TypeScript in declaration-only mode to preserve the existing `.d.ts` outputs and strict type checking.
+3. Transform source `.ts` and `.tsx` files with `@babel/preset-typescript`.
+4. For `.tsx`, also apply `babel-preset-solid` with `moduleName: "@opentui/solid"` and `generate: "universal"`, matching OpenTUI Solid's documented transform.
+5. Preserve the source directory structure and current `.js` import specifiers in `dist`.
+
+The build dependencies will be declared directly in `devDependencies` rather than relying on transitive packages from OpenTUI.
+
+## Alternatives considered
+
+### Bun build plugin
+
+`@opentui/solid` ships a Bun plugin that applies the same transform. It is an official route, but adopting it would add Bun as a build-time requirement to a package whose existing installation, testing, and publishing flow is Node/npm based.
+
+### Imperative renderable updates
+
+The component could keep references to the three action rows and set colors manually whenever selection changes. This would only mask the visible highlight bug. Responsive sizes and any future reactive JSX attributes would remain frozen, creating more one-off update code and leaving the invalid build pipeline in place.
+
+## Build and error handling
+
+The build script will remove stale `dist` output, generate declarations, transform every supported source file, and fail immediately on type-check or transform errors. It will not silently retain a partially old build. The existing `prepare`, `test`, and `prepublishOnly` entry points will continue to call `npm run build`.
+
+## Testing
+
+Tests will be added before the build change and must initially fail against the current pipeline. Regression coverage will verify:
+
+- `tsconfig.json` preserves JSX.
+- the build command uses the Solid-aware build script;
+- built TSX does not import `@opentui/solid/jsx-runtime`;
+- the compiled selected-state styling contains Solid-generated reactive update machinery instead of a one-time conditional property;
+- package exports and declaration files remain present;
+- all existing interaction and plugin tests still pass.
+
+Because OpenTUI's native test renderer is unavailable under the repository's Node runtime on this machine, final behavior will also be verified in an actual OpenCode PTY using the packed local package. The check will open the Loop dialog, exercise `Down`, `Up`, `Tab`, pointer selection, and activation, and confirm that the visible highlight follows the selected action.
+
+## Local installation cleanup
+
+The diagnostic cache instrumentation used to identify the fault has already been removed. After implementation, both unversioned and `@latest` plugin caches will be removed, the fixed packed artifact will be installed locally, and the installed files will be checked to ensure they match the new reactive build rather than stale version `0.2.8` output.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,13 @@
         "clipboardy": "4.0.0"
       },
       "devDependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/preset-typescript": "^7.27.1",
         "@opencode-ai/plugin": "^1.17.18",
         "@opentui/core": "0.4.3",
         "@opentui/solid": "0.4.3",
         "@types/node": "^22.0.0",
+        "babel-preset-solid": "^1.9.12",
         "solid-js": "1.9.12",
         "typescript": "^5.4.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-plugin-loop",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "MIT",
       "dependencies": {
         "clipboardy": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "opencode": ">=1.17.18"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "node scripts/build.mjs",
     "prepare": "npm run build",
     "test": "npm run build && node --test tests/*.test.mjs",
     "dry-run": "npm publish --dry-run",
@@ -67,10 +67,13 @@
     "solid-js": "1.9.12"
   },
   "devDependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/preset-typescript": "^7.27.1",
     "@opencode-ai/plugin": "^1.17.18",
     "@opentui/core": "0.4.3",
     "@opentui/solid": "0.4.3",
     "@types/node": "^22.0.0",
+    "babel-preset-solid": "^1.9.12",
     "solid-js": "1.9.12",
     "typescript": "^5.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "/loop command for opencode — run prompts on a schedule (fixed, adaptive, or maintenance), modeled after Claude Code's /loop",
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,75 @@
+import { transformAsync } from "@babel/core"
+import presetTypeScript from "@babel/preset-typescript"
+import presetSolid from "babel-preset-solid"
+import { execFileSync } from "node:child_process"
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
+import { createRequire } from "node:module"
+import { dirname, extname, join, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const require = createRequire(import.meta.url)
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const sourceRoot = join(root, "src")
+const outputRoot = join(root, "dist")
+
+async function sourceFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(directory, entry.name)
+      if (entry.isDirectory()) return sourceFiles(path)
+      if (!entry.isFile() || entry.name.endsWith(".d.ts")) return []
+      return [".ts", ".tsx"].includes(extname(entry.name)) ? [path] : []
+    }),
+  )
+  return nested.flat()
+}
+
+async function transformSource(path) {
+  const isTsx = extname(path) === ".tsx"
+  const presets = [
+    ...(isTsx
+      ? [
+          [
+            presetSolid,
+            { moduleName: "@opentui/solid", generate: "universal" },
+          ],
+        ]
+      : []),
+    [presetTypeScript, { allExtensions: true, isTSX: isTsx }],
+  ]
+  const result = await transformAsync(await readFile(path, "utf8"), {
+    filename: path,
+    babelrc: false,
+    configFile: false,
+    presets,
+    sourceMaps: false,
+  })
+
+  if (typeof result?.code !== "string") {
+    throw new Error(`Babel produced no JavaScript for ${relative(root, path)}`)
+  }
+
+  const outputPath = join(
+    outputRoot,
+    `${relative(sourceRoot, path).replace(/\.tsx?$/, "")}.js`,
+  )
+  await mkdir(dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, `${result.code}\n`, "utf8")
+}
+
+async function build() {
+  await rm(outputRoot, { recursive: true, force: true })
+
+  const tsc = require.resolve("typescript/bin/tsc")
+  execFileSync(
+    process.execPath,
+    [tsc, "-p", join(root, "tsconfig.json"), "--emitDeclarationOnly"],
+    { cwd: root, stdio: "inherit" },
+  )
+
+  const files = await sourceFiles(sourceRoot)
+  await Promise.all(files.map(transformSource))
+}
+
+await build()

--- a/tests/package-exports.test.mjs
+++ b/tests/package-exports.test.mjs
@@ -13,8 +13,8 @@ const builtDialogView = await readFile(
   "utf8",
 )
 
-test("publishes the interactive navigation release", () => {
-  assert.equal(packageJson.version, "0.2.8")
+test("publishes the reactive dialog release", () => {
+  assert.equal(packageJson.version, "0.2.9")
 })
 
 test("publishes explicit server and TUI plugin entrypoints", () => {

--- a/tests/package-exports.test.mjs
+++ b/tests/package-exports.test.mjs
@@ -5,6 +5,13 @@ import test from "node:test"
 const packageJson = JSON.parse(
   await readFile(new URL("../package.json", import.meta.url), "utf8"),
 )
+const tsconfig = JSON.parse(
+  await readFile(new URL("../tsconfig.json", import.meta.url), "utf8"),
+)
+const builtDialogView = await readFile(
+  new URL("../dist/tui-dialog-view.js", import.meta.url),
+  "utf8",
+)
 
 test("publishes the interactive navigation release", () => {
   assert.equal(packageJson.version, "0.2.8")
@@ -45,4 +52,24 @@ test("declares the host TUI peers used by the responsive dialog", () => {
 
 test("test command always builds fresh output before running tests", () => {
   assert.match(packageJson.scripts.test, /^npm run build && /)
+})
+
+test("preserves TSX for the OpenTUI Solid compiler", () => {
+  assert.equal(tsconfig.compilerOptions.jsx, "preserve")
+})
+
+test("builds JavaScript through the Solid-aware build script", () => {
+  assert.equal(packageJson.scripts.build, "node scripts/build.mjs")
+})
+
+test("emits reactive Solid updates for selected dialog rows", () => {
+  assert.doesNotMatch(builtDialogView, /@opentui\/solid\/jsx-runtime/)
+  assert.match(
+    builtDialogView,
+    /import \{ effect as \S+ \} from ["']@opentui\/solid["']/,
+  )
+  assert.match(
+    builtDialogView,
+    /setProp\([^\n]+["']backgroundColor["'][^\n]+\)/,
+  )
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "sourceMap": false,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "jsxImportSource": "@opentui/solid"
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Summary

- compile the OpenTUI TSX dialog with Solid's universal reactive transform
- preserve declaration generation while removing the non-reactive react-jsx output
- add a packaged-output regression test for reactive selection updates
- prepare release 0.2.9

## Root cause

Keyboard and mouse events updated the selected Solid signal, but the previous TypeScript react-jsx build evaluated row styling only once. The selected index changed internally while the rendered highlight remained frozen.

## Verification

- npm test: 124 tests passed
- npm publish --dry-run: opencode-plugin-loop@0.2.9 packed successfully
- real OpenCode TUI: Down cycles Copy ID -> Copy all -> Close -> Copy ID
- Enter copies the task ID and closes the dialog
- mouse hover selects Copy all and mouse click activates it and closes the dialog
- test task cleanup confirmed by /loop list showing no tasks
