### PR TITLE
release: adaptive scheduling 0.2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A drop-in `/loop` command for [opencode](https://opencode.ai), modeled after Cla
 ## Features
 
 - **`/loop 5m <prompt>`** — fixed interval (s/m/h/d supported)
-- **`/loop <prompt>`** — adaptive interval (1 min–1 hr, LLM-decided)
+- **`/loop <prompt>`** — adaptive interval with a random 1 min–1 hr fallback that the LLM can override from the execution result
 - **`/loop`** — bare: read `.opencode/loop.md` or run built-in maintenance
 - **Per-session scoping** — tasks are bound to a `sessionID`; other sessions never see or fire them
 - **Subcommands** — `list | status | cancel | pause | resume | stop-all` (session-scoped; add `--all` to cross sessions)
-- **Internal ticker** — 15s loop drives task firing (no longer depends on `session.idle` events)
+- **Internal ticker** — 5s loop drives task firing (no longer depends on `session.idle` events)
 - **Inflight guard** — double-set at ticker and `fireTask` level prevents double-firing even if opencode hot-reloads the plugin
 - **Persistent tasks** — survive session restarts; auto-migrated (tasks without `sessionID` are dropped on load)
 - **Auto-cleanup on `session.deleted`** — all tasks for that session are cancelled automatically
@@ -112,7 +112,9 @@ Re-run `npm run build` after editing `src/`, then restart OpenCode to load the r
 /loop check whether CI passed and address any review comments
 ```
 
-The LLM receives the prompt each iteration and uses `loop_schedule` to pick the next interval (1–60 min).
+Each Adaptive task receives a persisted random fallback time inside the configured 1–60 minute range. On every iteration, the LLM first completes the user request and evaluates the current session state and execution result. It calls `loop_schedule(action="reschedule")` only when that evidence justifies an earlier or later run, leaves the random fallback unchanged when it is suitable, or calls `loop_schedule(action="cancel")` when no future check is useful.
+
+The fallback is written before the prompt is injected. A successful `reschedule` therefore replaces the fallback and is not overwritten after the model finishes. An in-range model time is stored exactly without Jitter; only an out-of-range request is clamped to the task's configured minimum or maximum delay. Fixed and Maintenance rescheduling remains unchanged.
 
 ### Bare `/loop` — custom default prompt
 Create `.opencode/loop.md` (project) or `<user>/.opencode/loop.md` (user) with your maintenance instructions:
@@ -180,20 +182,22 @@ loop_status({ all: true })     // all sessions
 
 ## Configuration
 
-Pass options via `opencode.json`:
+The package name in the `plugin` array is the only plugin-specific entry required in
+`opencode.json`. Current OpenCode releases validate that file and reject arbitrary
+top-level keys such as `"opencode-plugin-loop"`.
 
-```json
-{
-  "plugin": ["opencode-plugin-loop"],
-  "opencode-plugin-loop": {
-    "maxTasks": 50,
-    "taskTtlDays": 7,
-    "defaultAdaptiveMinMs": 60000,
-    "defaultAdaptiveMaxMs": 3600000,
-    "tickerIntervalMs": 15000
-  }
-}
-```
+The built-in runtime defaults are:
+
+| Setting | Default |
+|---------|---------|
+| Maximum persisted tasks | 50 |
+| Task expiry | 7 days |
+| Adaptive fallback range | 1 minute to 1 hour |
+| Scheduler ticker | 5 seconds |
+
+Adaptive minimum and maximum delays are persisted on each task. The random fallback
+and any model-requested `reschedule` are both constrained by that task's bounds. Jitter
+is not added to a model-selected Adaptive time.
 
 ## Per-session architecture
 
@@ -202,7 +206,7 @@ Each `/loop` task carries a `sessionID` field:
 | Lifecycle event | Behavior |
 |-----------------|----------|
 | User runs `/loop` in session A | Task created with `sessionID = A` |
-| Ticker fires every 15s | Only fires tasks where `sessionID === activeSessionID` (tracked via `chat.message` hook) |
+| Ticker fires every 5s | Only fires tasks where `sessionID === activeSessionID` (tracked via `chat.message` hook) |
 | User runs `/loop` in session B | Session B becomes active; A's task waits |
 | `session.deleted` for session A | All A's tasks cancelled automatically |
 | Plugin reload (`opencode` hot-reload) | Old tickers stop, new ticker starts; in-flight tasks guarded by `inflight` Set |

--- a/docs/superpowers/plans/2026-07-18-adaptive-reschedule.md
+++ b/docs/superpowers/plans/2026-07-18-adaptive-reschedule.md
@@ -1,0 +1,242 @@
+# Adaptive Reschedule Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Adaptive tasks a random fallback schedule and a model-facing decision protocol while guaranteeing that a successful `loop_schedule(action="reschedule")` call remains authoritative.
+
+**Architecture:** A new pure Adaptive policy module owns bound normalization, random delay selection, absolute-time clamping, and prompt construction. The Scheduler pre-arms Adaptive tasks before prompt injection, then performs no later Adaptive scheduling write, so model tool calls override the fallback without relying on OpenCode prompt completion timing.
+
+**Tech Stack:** TypeScript ESM, OpenCode plugin APIs, Zod tools, Node.js test runner, JSON task store.
+
+## Global Constraints
+
+- Adaptive fallback delays must be inside the task's inclusive `adaptiveMinMs` to `adaptiveMaxMs` range.
+- Production randomness uses `Math.random`; tests inject deterministic random sources.
+- A successful Adaptive `reschedule` must never be overwritten after model execution.
+- Fixed and Maintenance scheduling semantics must remain unchanged.
+- Existing persisted task schema version stays at `1`.
+- No new runtime dependency or public entrypoint is added.
+- Do not commit implementation changes, push, or publish before the user reviews local OpenCode verification results.
+
+---
+
+### Task 1: Pure Adaptive policy
+
+**Files:**
+- Create: `src/adaptive-policy.ts`
+- Create: `tests/adaptive-policy.test.mjs`
+
+**Interfaces:**
+- Produces: `adaptiveBounds(task, defaults)`, `randomAdaptiveNextDueAt(task, defaults, random, now)`, `clampAdaptiveNextDueAt(task, defaults, requestedAt, now)`, and `buildAdaptiveExecutionPrompt(task)`.
+- Consumes: `LoopTask` and Scheduler default minimum/maximum values.
+
+- [ ] **Step 1: Write failing policy tests**
+
+Cover random source values `0`, `0.5`, and `0.999999`; reversed bounds; below/above-bound absolute times; prompt inclusion of the original request, task ID, bounds, persisted fallback epoch/ISO value, `reschedule`, and `cancel` guidance.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+npm run build && node --test tests/adaptive-policy.test.mjs
+```
+
+Expected: failure because `dist/adaptive-policy.js` does not exist.
+
+- [ ] **Step 3: Implement the minimal pure policy**
+
+Use normalized finite integer millisecond bounds. Clamp the random source into `[0, 1)` and calculate an inclusive integer offset:
+
+```ts
+const delay = minMs + Math.floor(unit * (maxMs - minMs + 1))
+```
+
+Build a wrapper that preserves the exact user prompt and states that the model must finish the work before deciding whether to keep the fallback, reschedule, or cancel.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the same command and expect all Adaptive policy tests to pass.
+
+### Task 2: Random fallback on Adaptive creation
+
+**Files:**
+- Modify: `src/scheduler.ts`
+- Modify: `src/tools/loop-tools.ts`
+- Modify: `tests/scheduler.test.mjs`
+- Modify: `tests/per-session.test.mjs`
+
+**Interfaces:**
+- Scheduler consumes an optional `random?: () => number` dependency.
+- Scheduler produces `rearmAdaptive(task, now?)` and uses the policy helper for task-specific bounds.
+- `loop_schedule(create)` calls `scheduler.rearmAdaptive()` for Adaptive tasks.
+
+- [ ] **Step 1: Write failing creation tests**
+
+Assert `/loop <prompt>` and `loop_schedule(action="create", mode="adaptive")` persist midpoint fallback times when the injected random source returns `0.5`.
+
+- [ ] **Step 2: Verify RED**
+
+Run the two focused test files and confirm existing behavior still chooses `adaptiveMaxMs`.
+
+- [ ] **Step 3: Implement minimal Scheduler and Tool changes**
+
+Store the random dependency in Scheduler options, add `rearmAdaptive`, and call it immediately after Adaptive task creation. Do not change Fixed or Maintenance creation.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run focused Scheduler and per-session tests and expect them to pass.
+
+### Task 3: Pre-arm before model execution
+
+**Files:**
+- Modify: `src/scheduler.ts`
+- Modify: `src/index.ts`
+- Modify: `tests/integration.test.mjs`
+- Modify: `tests/per-session.test.mjs`
+
+**Interfaces:**
+- Scheduler produces `executeTask(task, ctx, now?)`.
+- The ticker delegates fire/reschedule ordering to `executeTask`.
+- Adaptive execution pre-arms and wraps the prompt; Fixed and Maintenance retain post-fire scheduling.
+
+- [ ] **Step 1: Write failing ordering tests**
+
+Use a fake `client.session.prompt` that inspects the store before returning and then calls `store.reschedule`. Assert:
+
+```text
+fallback persisted before prompt callback
+model reschedule value remains after executeTask returns
+no model reschedule leaves fallback unchanged
+```
+
+Also assert Fixed scheduling still happens after prompt execution.
+
+- [ ] **Step 2: Verify RED**
+
+Run the focused integration and per-session tests. Expect failure because the ticker currently writes `markFired` after `fireTask`.
+
+- [ ] **Step 3: Implement execution orchestration**
+
+For Adaptive tasks:
+
+```ts
+await scheduler.rearmAdaptive(task, now, true)
+await scheduler.fireTask(task, ctx)
+```
+
+The pre-arm path must update `lastFiredAt` and `nextDueAt` through `store.markFired`. `fireTask` must inject `buildAdaptiveExecutionPrompt(task)` after the stored task reflects the fallback.
+
+For other modes, retain:
+
+```ts
+await scheduler.fireTask(task, ctx)
+await store.markFired(task.id, await scheduler.nextDueAt(task))
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+Run focused tests and verify the model override remains authoritative.
+
+### Task 4: Adaptive Tool bound enforcement
+
+**Files:**
+- Modify: `src/tools/loop-tools.ts`
+- Modify: `tests/integration.test.mjs`
+- Modify: `tests/per-session.test.mjs`
+
+**Interfaces:**
+- Adaptive `reschedule` consumes task-specific bounds and Scheduler defaults.
+- Its JSON result exposes `requestedNextDueAt` when provided and the final `nextDueAt`.
+- Fixed and Maintenance rescheduling keeps existing unrestricted absolute-time behavior.
+
+- [ ] **Step 1: Write failing Tool tests**
+
+Test values below the minimum, inside the range, above the maximum, and omitted. Assert the effective persisted time and returned JSON.
+
+- [ ] **Step 2: Verify RED**
+
+Run focused tests and confirm the current Tool accepts out-of-range times unchanged.
+
+- [ ] **Step 3: Implement Adaptive-only clamping**
+
+Use tool-call `Date.now()` as the range origin. When `nextDueAtMs` is omitted, call the Scheduler Adaptive random helper. Do not clamp Fixed or Maintenance tasks.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run focused tests and confirm all four Adaptive cases plus compatibility cases pass.
+
+### Task 5: Documentation and full verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `src/types.ts`
+
+**Interfaces:**
+- Documents the actual 5-second ticker and Adaptive fallback/override contract.
+
+- [ ] **Step 1: Update documentation**
+
+Replace stale 15-second default statements with 5 seconds, explain random fallback scheduling, model override behavior, cancellation semantics, and the task-specific bound enforcement.
+
+- [ ] **Step 2: Run static checks**
+
+```bash
+rg -n "15s|15_000|tickerIntervalMs" README.md src
+git diff --check
+```
+
+Expected: no stale default claim; no whitespace errors.
+
+- [ ] **Step 3: Run complete verification**
+
+```bash
+npm test
+npm pack --dry-run --json
+```
+
+Expected: all existing and new tests pass; the npm package contains server/TUI entrypoints and the new policy module.
+
+### Task 6: Real OpenCode host verification
+
+**Files:**
+- No source files beyond the preceding tasks.
+- Runtime evidence: project `.opencode/cache/loop/tasks.json` and OpenCode structured log/history.
+
+**Interfaces:**
+- Uses the local file-plugin installer and the installed OpenCode CLI/TUI.
+
+- [ ] **Step 1: Inspect the installed OpenCode version and current plugin entries**
+
+Record the OpenCode version and existing `opencode.json` / `tui.json` plugin values without exposing unrelated configuration secrets.
+
+- [ ] **Step 2: Build and install the worktree**
+
+```bash
+npm run build
+opencode plugin "file:///Users/wangshuai/Projects/opencode-loop/.worktrees/responsive-loop-dialog" --global --force
+```
+
+Remove only stale `opencode-plugin-loop` package cache entries that are confirmed to belong to earlier versions; preserve unrelated caches.
+
+- [ ] **Step 3: Start OpenCode and create an Adaptive task**
+
+Use a short test configuration for Adaptive bounds, run an Adaptive `/loop` prompt that asks the model to inspect a deterministic result, and observe the injected scheduling instructions.
+
+- [ ] **Step 4: Verify fallback and override behavior**
+
+Confirm from `tasks.json` and host output that:
+
+- the initial and next fallback times are inside the configured range;
+- the fallback exists before the model executes;
+- a successful model `reschedule` changes `nextDueAt`;
+- no post-run write restores the fallback;
+- the dialog remains keyboard/mouse accessible.
+
+- [ ] **Step 5: Restore normal local configuration**
+
+Remove test tasks and restore any temporary Adaptive bounds. Keep the local file plugin installed only if it replaces the pre-existing plugin entry cleanly.
+
+- [ ] **Step 6: Report without committing or publishing**
+
+Provide test counts, observed timestamps, model scheduling decision, dialog behavior, modified files, and remaining risks. Leave implementation changes uncommitted for user review.

--- a/docs/superpowers/specs/2026-07-18-adaptive-reschedule-design.md
+++ b/docs/superpowers/specs/2026-07-18-adaptive-reschedule-design.md
@@ -1,0 +1,117 @@
+# Adaptive Reschedule Design
+
+## Goal
+
+Improve Adaptive mode so each task has a random fallback execution time inside its configured minimum and maximum interval, while allowing the model to replace that fallback by calling `loop_schedule(action="reschedule")` after evaluating the user's request and the current execution result.
+
+## Confirmed Semantics
+
+- An Adaptive task always has a persisted fallback `nextDueAt`.
+- The fallback delay is a uniform random millisecond value in the task's inclusive `adaptiveMinMs` to `adaptiveMaxMs` range.
+- The model calls `reschedule` only when the observed result justifies a better execution time.
+- If the fallback time is appropriate, the model does not call `reschedule` and the fallback remains effective.
+- If no future execution is needed, the model calls `cancel`.
+- A successful model `reschedule` is authoritative and must not be overwritten after the model run finishes.
+- Fixed and Maintenance scheduling behavior remains unchanged.
+
+## Recommended Architecture
+
+### Adaptive policy module
+
+Create `src/adaptive-policy.ts` as a small pure module responsible for:
+
+- normalizing Adaptive bounds;
+- choosing a random delay through an injected `() => number` source;
+- clamping a requested absolute next-run time to the task's allowed relative range;
+- building the model-facing Adaptive execution prompt.
+
+The production random source is `Math.random`. Tests inject fixed values such as `0`, `0.5`, and a value close to `1`, so boundary and midpoint behavior is deterministic.
+
+### Scheduler orchestration
+
+Extend `SchedulerOptions` with an optional random source and add focused Adaptive helpers to `SchedulerInstance`.
+
+When an Adaptive task is created by `/loop <prompt>` or `loop_schedule(action="create")`, immediately replace the store's initial maximum-bound time with a random fallback time.
+
+When an existing Adaptive task becomes due, persist its next random fallback before injecting its prompt into OpenCode. The execution order is:
+
+1. calculate random fallback;
+2. call `store.markFired(task.id, fallbackNextDueAt)`;
+3. inject the Adaptive prompt into the owning session;
+4. allow the model to keep the fallback, override it with `reschedule`, or remove the task with `cancel`;
+5. perform no later Adaptive `markFired` write.
+
+This ordering makes model tool writes authoritative regardless of whether `client.session.prompt()` waits for model completion or returns after queueing the prompt.
+
+Fixed and Maintenance tasks retain the existing order: fire first, then calculate and persist their normal next execution time.
+
+## Adaptive Prompt Contract
+
+Only Adaptive tasks receive the scheduling wrapper. The injected text contains:
+
+- the original user request without modification;
+- the task ID;
+- the minimum and maximum delay in milliseconds;
+- the already persisted fallback `nextDueAt` as epoch milliseconds and ISO time;
+- an instruction to execute the user request before deciding scheduling;
+- guidance to use a shorter delay for rapidly changing, pending, or retryable conditions;
+- guidance to use a longer delay for stable or slow-moving conditions;
+- an instruction to call `reschedule` exactly when a different time is justified;
+- an instruction to make no scheduling call when the fallback is suitable;
+- an instruction to call `cancel` when the task is fully complete;
+- an instruction not to claim a scheduling change unless the tool succeeds.
+
+The model sees the current session history and the results of the work it performs, so the decision is made after observing the current execution outcome rather than from the original text alone.
+
+## Tool Behavior
+
+For Adaptive tasks, `loop_schedule(action="reschedule")` clamps the requested absolute `nextDueAtMs` to:
+
+```text
+[toolCallTime + adaptiveMinMs, toolCallTime + adaptiveMaxMs]
+```
+
+The response returns both the requested time and final effective time when they differ. Omitting `nextDueAtMs` selects a fresh random fallback inside the same range.
+
+Fixed and Maintenance task rescheduling retains the current unrestricted absolute-time behavior to avoid an unrelated compatibility change.
+
+## Data and Compatibility
+
+- No persisted state version change is required.
+- Existing Adaptive tasks already contain `adaptiveMinMs`, `adaptiveMaxMs`, and `nextDueAt`.
+- Legacy tasks missing bounds fall back to the Scheduler's configured defaults.
+- No new runtime dependency is introduced.
+- Public package entrypoints remain unchanged.
+
+## Error Handling
+
+- Normalize reversed or invalid bounds before random selection or clamping.
+- Clamp abnormal random-source output into the valid `[0, 1)` range.
+- Persist the fallback before prompt injection so a failed injection does not leave the task immediately due on every ticker cycle.
+- Preserve the existing structured logging and fire-history behavior.
+- A failed `reschedule` tool call leaves the persisted fallback intact.
+
+## Testing
+
+Add test-first coverage for:
+
+- minimum, midpoint, and maximum-edge random delays;
+- initial Adaptive task creation receiving a random fallback;
+- model-facing prompt contents and original user request preservation;
+- fallback persistence before `client.session.prompt()` is called;
+- a reschedule performed during prompt execution overriding the fallback;
+- no reschedule preserving the fallback;
+- Adaptive requested times below and above bounds being clamped;
+- Adaptive reschedule without a requested time choosing a random time;
+- Fixed and Maintenance scheduling remaining unchanged;
+- the end-to-end ticker path using the new Scheduler execution orchestration.
+
+Run the complete `npm test` suite, install the worktree through OpenCode's file-plugin installer, clear stale plugin cache, restart OpenCode, create a short Adaptive task, and inspect the persisted task plus execution output to verify the random fallback and model scheduling instructions in the real host.
+
+## Out of Scope
+
+- Changing Fixed jitter behavior.
+- Changing Maintenance scheduling semantics.
+- Adding a new UI control for Adaptive timing.
+- Changing the task store schema version.
+- Publishing npm or pushing the implementation branch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-plugin-loop",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "MIT",
       "dependencies": {
         "clipboardy": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "/loop command for opencode — run prompts on a schedule (fixed, adaptive, or maintenance), modeled after Claude Code's /loop",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/adaptive-policy.ts
+++ b/src/adaptive-policy.ts
@@ -1,0 +1,74 @@
+import type { LoopTask } from "./types.js"
+
+export interface AdaptiveDefaults {
+  minMs: number
+  maxMs: number
+}
+
+function validBound(value: number | undefined, fallback: number): number {
+  if (!Number.isFinite(value) || (value ?? 0) < 0) return Math.max(0, Math.floor(fallback))
+  return Math.floor(value as number)
+}
+
+export function adaptiveBounds(
+  task: Pick<LoopTask, "adaptiveMinMs" | "adaptiveMaxMs">,
+  defaults: AdaptiveDefaults
+): AdaptiveDefaults {
+  const first = validBound(task.adaptiveMinMs, defaults.minMs)
+  const second = validBound(task.adaptiveMaxMs, defaults.maxMs)
+  return {
+    minMs: Math.min(first, second),
+    maxMs: Math.max(first, second),
+  }
+}
+
+function randomUnit(random: () => number): number {
+  const value = random()
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(1 - Number.EPSILON, value))
+}
+
+export function randomAdaptiveNextDueAt(
+  task: Pick<LoopTask, "adaptiveMinMs" | "adaptiveMaxMs">,
+  defaults: AdaptiveDefaults,
+  random: () => number = Math.random,
+  now: number = Date.now()
+): number {
+  const { minMs, maxMs } = adaptiveBounds(task, defaults)
+  const delay = minMs + Math.floor(randomUnit(random) * (maxMs - minMs + 1))
+  return now + delay
+}
+
+export function clampAdaptiveNextDueAt(
+  task: Pick<LoopTask, "adaptiveMinMs" | "adaptiveMaxMs">,
+  defaults: AdaptiveDefaults,
+  requestedAt: number,
+  now: number = Date.now()
+): number {
+  const { minMs, maxMs } = adaptiveBounds(task, defaults)
+  const requestedDelay = Number.isFinite(requestedAt) ? requestedAt - now : minMs
+  return now + Math.max(minMs, Math.min(maxMs, requestedDelay))
+}
+
+export function buildAdaptiveExecutionPrompt(
+  task: Pick<
+    LoopTask,
+    "id" | "prompt" | "adaptiveMinMs" | "adaptiveMaxMs" | "nextDueAt"
+  >,
+  defaults: AdaptiveDefaults
+): string {
+  const { minMs, maxMs } = adaptiveBounds(task, defaults)
+  const fallbackIso = new Date(task.nextDueAt).toISOString()
+
+  return `${task.prompt}
+
+<adaptive_loop_schedule>
+This is Adaptive loop task ${task.id}. Complete the user request above first. After observing the current session state and this execution's result, decide whether the next run needs a different time.
+
+A fallback run is already scheduled at ${task.nextDueAt} (${fallbackIso}), using the allowed delay range ${minMs}ms to ${maxMs}ms. Keep that fallback by making no scheduling tool call when it is appropriate.
+
+If the result justifies an earlier or later run, call loop_schedule exactly once with action="reschedule", taskId="${task.id}", and an absolute nextDueAtMs within Date.now() + ${minMs}ms to Date.now() + ${maxMs}ms. An accepted in-range time is stored without jitter; only an out-of-range request is clamped to the nearest bound. Prefer a shorter delay for pending, rapidly changing, or retryable conditions and a longer delay for stable or slow-moving conditions.
+
+If the task is fully complete and no future check is useful, call loop_schedule with action="cancel" and taskId="${task.id}". Do not claim that the schedule changed unless the tool call succeeds.
+</adaptive_loop_schedule>`
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@
  * Per-session architecture:
  *   - chat.message hook tracks the current active sessionID
  *   - command.execute.before also updates currentSessionID
- *   - 15s ticker fires ONLY tasks whose sessionID === currentSessionID
+ *   - 5s ticker fires ONLY tasks whose sessionID === currentSessionID
  *   - session.deleted event cancels all tasks for that session
  *   - On load, tasks without sessionID (legacy) are cleaned up
  */
@@ -91,7 +91,7 @@ export const LoopPlugin: Plugin = async (ctx) => {
     if (sid) activeSessionID = sid
   }
 
-  // Internal ticker: every 15s, fire any due tasks whose sessionID matches the active session.
+  // Internal ticker: every 5s, fire any due tasks whose sessionID matches the active session.
   // This replaces the old session.idle-event-driven firing and runs even when no user input.
   const inflight = new Set<string>()
   const ticker = setInterval(async () => {
@@ -104,9 +104,7 @@ export const LoopPlugin: Plugin = async (ctx) => {
         if (inflight.has(task.id)) continue
         inflight.add(task.id)
         try {
-          await scheduler.fireTask(task, ctx)
-          const next = await scheduler.nextDueAt(task)
-          await store.markFired(task.id, next)
+          await scheduler.executeTask(task, ctx)
         } finally {
           inflight.delete(task.id)
         }

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -17,6 +17,11 @@ import type { LoopStoreInstance as LoopStore } from "./store.js"
 import type { CronParserInstance as CronParser } from "./cron-parser.js"
 import type { JitterInstance as Jitter } from "./jitter.js"
 import { errorMessage, type LoopLogger } from "./runtime-feedback.js"
+import {
+  buildAdaptiveExecutionPrompt,
+  clampAdaptiveNextDueAt as clampAdaptivePolicyNextDueAt,
+  randomAdaptiveNextDueAt,
+} from "./adaptive-policy.js"
 
 export interface SchedulerOptions {
   store: LoopStore
@@ -25,6 +30,7 @@ export interface SchedulerOptions {
   adaptiveMinMs: number
   adaptiveMaxMs: number
   logger?: LoopLogger
+  random?: () => number
 }
 
 export interface CommandParseResult {
@@ -46,8 +52,12 @@ interface SchedulerInstance {
   getDueTasks(now?: number): Promise<LoopTask[]>
   getDueTasksForSession(sessionID: string, now?: number): Promise<LoopTask[]>
   nextDueAt(task: LoopTask, now?: number): Promise<number>
+  executeTask(task: LoopTask, ctx: any, now?: number): Promise<void>
   fireTask(task: LoopTask, ctx: any): Promise<void>
   rearmFixed(task: LoopTask, now?: number): Promise<void>
+  rearmAdaptive(task: LoopTask, now?: number): Promise<void>
+  adaptiveNextDueAt(task: LoopTask, now?: number): number
+  clampAdaptiveNextDueAt(task: LoopTask, requestedAt: number, now?: number): number
   clampAdaptive(ms: number): number
 }
 
@@ -56,6 +66,7 @@ export type { SchedulerInstance }
 export function Scheduler(this: unknown, opts: SchedulerOptions): SchedulerInstance {
   void this
   const logger: LoopLogger = opts.logger ?? (async () => {})
+  const random = opts.random ?? Math.random
   const inst: SchedulerInstance = {
     opts,
     currentSessionID: null,
@@ -148,6 +159,7 @@ export function Scheduler(this: unknown, opts: SchedulerOptions): SchedulerInsta
           source: "user",
           sessionID,
         })
+        await inst.rearmAdaptive(task)
         return {
           task,
           message: `🔁 Loop started (adaptive ${inst.opts.adaptiveMinMs / 1000}s–${inst.opts.adaptiveMaxMs / 1000}s): "${trimmed.slice(0, 50)}${trimmed.length > 50 ? "..." : ""}" [id=${task.id}] [s=${sessionID.slice(0, 8)}]. Cancel: \`/loop cancel ${task.id}\``,
@@ -256,9 +268,27 @@ export function Scheduler(this: unknown, opts: SchedulerOptions): SchedulerInsta
         return now + task.adaptiveMaxMs
       }
       if (task.mode === "adaptive" && task.adaptiveMaxMs) {
-        return now + task.adaptiveMaxMs
+        return inst.adaptiveNextDueAt(task, now)
       }
       return now + 60_000
+    },
+
+    async executeTask(task, ctx, now) {
+      if (task.mode === "adaptive") {
+        const fallbackNextDueAt = randomAdaptiveNextDueAt(
+          task,
+          { minMs: inst.opts.adaptiveMinMs, maxMs: inst.opts.adaptiveMaxMs },
+          random,
+          now ?? Date.now()
+        )
+        await inst.opts.store.markFired(task.id, fallbackNextDueAt)
+        await inst.fireTask(task, ctx)
+        return
+      }
+
+      await inst.fireTask(task, ctx)
+      const next = await inst.nextDueAt(task, now ?? Date.now())
+      await inst.opts.store.markFired(task.id, next)
     },
 
     async fireTask(task, ctx) {
@@ -266,7 +296,13 @@ export function Scheduler(this: unknown, opts: SchedulerOptions): SchedulerInsta
       inst.inflight.add(task.id)
       try {
         const sessionID = task.sessionID
-        const text = task.prompt
+        const text =
+          task.mode === "adaptive"
+            ? buildAdaptiveExecutionPrompt(task, {
+                minMs: inst.opts.adaptiveMinMs,
+                maxMs: inst.opts.adaptiveMaxMs,
+              })
+            : task.prompt
         const directory = task.directory || ctx?.directory || process.cwd()
         const client = ctx?.client
 
@@ -312,6 +348,29 @@ export function Scheduler(this: unknown, opts: SchedulerOptions): SchedulerInsta
       if (!task.intervalMs) return
       const jitterMs = inst.opts.jitter.compute(task.id, task.intervalMs, now)
       await inst.opts.store.reschedule(task.id, now + task.intervalMs + jitterMs)
+    },
+
+    async rearmAdaptive(task, now: number = Date.now()) {
+      if (task.mode !== "adaptive") return
+      await inst.opts.store.reschedule(task.id, inst.adaptiveNextDueAt(task, now))
+    },
+
+    adaptiveNextDueAt(task, now: number = Date.now()) {
+      return randomAdaptiveNextDueAt(
+        task,
+        { minMs: inst.opts.adaptiveMinMs, maxMs: inst.opts.adaptiveMaxMs },
+        random,
+        now
+      )
+    },
+
+    clampAdaptiveNextDueAt(task, requestedAt, now: number = Date.now()) {
+      return clampAdaptivePolicyNextDueAt(
+        task,
+        { minMs: inst.opts.adaptiveMinMs, maxMs: inst.opts.adaptiveMaxMs },
+        requestedAt,
+        now
+      )
     },
 
     clampAdaptive(ms) {

--- a/src/tools/loop-tools.ts
+++ b/src/tools/loop-tools.ts
@@ -145,6 +145,7 @@ export async function buildLoopTools(
               input.adaptiveMaxMs = 3_600_000
             }
             const task = await store.create(input)
+            if (task.mode === "adaptive") await scheduler.rearmAdaptive(task)
             return JSON.stringify(
               {
                 ok: true,
@@ -173,11 +174,21 @@ export async function buildLoopTools(
                 error: `Task belongs to another session. Pass all=true to override.`,
               })
             }
-            const next = args.nextDueAtMs ?? Date.now() + scheduler.clampAdaptive(5 * 60_000)
+            const requestedNextDueAt = args.nextDueAtMs
+            const next =
+              t.mode === "adaptive"
+                ? requestedNextDueAt === undefined
+                  ? scheduler.adaptiveNextDueAt(t)
+                  : scheduler.clampAdaptiveNextDueAt(t, requestedNextDueAt)
+                : requestedNextDueAt ?? Date.now() + scheduler.clampAdaptive(5 * 60_000)
             const r = await store.reschedule(args.taskId, next)
             return JSON.stringify(
               {
                 ok: !!r,
+                requestedNextDueAt:
+                  requestedNextDueAt === undefined
+                    ? undefined
+                    : new Date(requestedNextDueAt).toISOString(),
                 task: r ? { id: r.id, nextDueAt: new Date(r.nextDueAt).toISOString() } : null,
               },
               null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export interface LoopConfig {
   defaultAdaptiveMinMs?: number
   /** Adaptive maximum interval in ms (default 3_600_000) */
   defaultAdaptiveMaxMs?: number
-  /** Internal ticker interval in ms (default 15_000) */
+  /** Internal ticker interval in ms (default 5_000) */
   tickerIntervalMs?: number
 }
 

--- a/tests/adaptive-policy.test.mjs
+++ b/tests/adaptive-policy.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import {
+  adaptiveBounds,
+  buildAdaptiveExecutionPrompt,
+  clampAdaptiveNextDueAt,
+  randomAdaptiveNextDueAt,
+} from "../dist/adaptive-policy.js"
+
+const defaults = { minMs: 60_000, maxMs: 3_600_000 }
+
+function task(overrides = {}) {
+  return {
+    id: "adaptive1",
+    prompt: "Check the deployment and report the current result.",
+    mode: "adaptive",
+    adaptiveMinMs: 1_000,
+    adaptiveMaxMs: 3_000,
+    createdAt: 1,
+    lastFiredAt: 0,
+    nextDueAt: 12_000,
+    source: "user",
+    directory: "/tmp/project",
+    sessionID: "session-a",
+    paused: false,
+    ...overrides,
+  }
+}
+
+test("normalizes task-specific adaptive bounds", () => {
+  assert.deepEqual(adaptiveBounds(task(), defaults), { minMs: 1_000, maxMs: 3_000 })
+  assert.deepEqual(
+    adaptiveBounds(task({ adaptiveMinMs: 4_000, adaptiveMaxMs: 1_000 }), defaults),
+    { minMs: 1_000, maxMs: 4_000 }
+  )
+  assert.deepEqual(
+    adaptiveBounds(task({ adaptiveMinMs: Number.NaN, adaptiveMaxMs: undefined }), defaults),
+    defaults
+  )
+})
+
+test("selects minimum, midpoint, and maximum-edge random fallback times", () => {
+  const now = 10_000
+  assert.equal(randomAdaptiveNextDueAt(task(), defaults, () => 0, now), 11_000)
+  assert.equal(randomAdaptiveNextDueAt(task(), defaults, () => 0.5, now), 12_000)
+  assert.equal(randomAdaptiveNextDueAt(task(), defaults, () => 0.999999, now), 13_000)
+})
+
+test("clamps requested absolute times to adaptive bounds", () => {
+  const now = 10_000
+  assert.equal(clampAdaptiveNextDueAt(task(), defaults, 10_500, now), 11_000)
+  assert.equal(clampAdaptiveNextDueAt(task(), defaults, 12_000, now), 12_000)
+  assert.equal(clampAdaptiveNextDueAt(task(), defaults, 15_000, now), 13_000)
+})
+
+test("builds an execution prompt that preserves the request and explains scheduling", () => {
+  const value = buildAdaptiveExecutionPrompt(task(), defaults)
+
+  assert.match(value, /Check the deployment and report the current result\./)
+  assert.match(value, /adaptive1/)
+  assert.match(value, /1000/)
+  assert.match(value, /3000/)
+  assert.match(value, /12000/)
+  assert.match(value, new RegExp(new Date(12_000).toISOString().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
+  assert.match(value, /loop_schedule/)
+  assert.match(value, /reschedule/)
+  assert.match(value, /cancel/)
+  assert.match(value, /fallback/i)
+  assert.match(value, /after.*result/i)
+  assert.match(value, /without jitter/i)
+})

--- a/tests/package-exports.test.mjs
+++ b/tests/package-exports.test.mjs
@@ -13,8 +13,8 @@ const builtDialogView = await readFile(
   "utf8",
 )
 
-test("publishes the reactive dialog release", () => {
-  assert.equal(packageJson.version, "0.2.9")
+test("publishes the Adaptive scheduling release", () => {
+  assert.equal(packageJson.version, "0.2.10")
 })
 
 test("publishes explicit server and TUI plugin entrypoints", () => {

--- a/tests/per-session.test.mjs
+++ b/tests/per-session.test.mjs
@@ -23,7 +23,7 @@ import { buildLoopTools } from "../dist/tools/loop-tools.js"
 const SID_A = "sess-aaa-aaaa"
 const SID_B = "sess-bbb-bbbb"
 
-function makeScheduler() {
+function makeScheduler(random) {
   const dir = mkdtempSync(join(tmpdir(), "loop-persess-"))
   const store = new LoopStore({ storageDir: dir, maxTasks: 20, taskTtlMs: 86_400_000 })
   const sched = new Scheduler({
@@ -32,6 +32,7 @@ function makeScheduler() {
     jitter: new Jitter(),
     adaptiveMinMs: 60_000,
     adaptiveMaxMs: 3_600_000,
+    random,
   })
   return { store, sched, dir }
 }
@@ -396,6 +397,91 @@ test("fireTask: after inflight release, same task can fire again", async () => {
   }
 })
 
+test("executeTask pre-arms adaptive fallback before prompt and preserves model override", async () => {
+  const { sched, store, dir } = makeScheduler(() => 0.5)
+  try {
+    const task = await store.create({
+      prompt: "inspect deployment",
+      mode: "adaptive",
+      adaptiveMinMs: 1_000,
+      adaptiveMaxMs: 3_000,
+      directory: "/tmp",
+      sessionID: SID_A,
+    })
+    await store.reschedule(task.id, 9_000)
+    let fallbackSeenDuringPrompt
+    let promptText
+    const client = {
+      session: {
+        async prompt(args) {
+          fallbackSeenDuringPrompt = store.get(task.id).nextDueAt
+          promptText = args.body.parts[0].text
+          await store.reschedule(task.id, 12_500)
+          return { info: {}, parts: [] }
+        },
+      },
+    }
+
+    await sched.executeTask(task, { client, directory: "/tmp" }, 10_000)
+
+    assert.equal(fallbackSeenDuringPrompt, 12_000)
+    assert.match(promptText, /inspect deployment/)
+    assert.match(promptText, /fallback/i)
+    assert.match(promptText, /taskId="[a-z0-9]+"/)
+    assert.equal(store.get(task.id).nextDueAt, 12_500, "model override remains authoritative")
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("executeTask keeps adaptive fallback when the model does not reschedule", async () => {
+  const { sched, store, dir } = makeScheduler(() => 0.5)
+  try {
+    const task = await store.create({
+      prompt: "inspect deployment",
+      mode: "adaptive",
+      adaptiveMinMs: 1_000,
+      adaptiveMaxMs: 3_000,
+      directory: "/tmp",
+      sessionID: SID_A,
+    })
+    await sched.executeTask(task, { client: mockClient(), directory: "/tmp" }, 10_000)
+    assert.equal(store.get(task.id).nextDueAt, 12_000)
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("executeTask retains post-fire scheduling for fixed tasks", async () => {
+  const { sched, store, dir } = makeScheduler(() => 0.5)
+  try {
+    const task = await store.create({
+      prompt: "fixed work",
+      mode: "fixed",
+      intervalMs: 60_000,
+      directory: "/tmp",
+      sessionID: SID_A,
+    })
+    await store.reschedule(task.id, 9_000)
+    let dueDuringPrompt
+    const client = {
+      session: {
+        async prompt() {
+          dueDuringPrompt = store.get(task.id).nextDueAt
+          return { info: {}, parts: [] }
+        },
+      },
+    }
+
+    await sched.executeTask(task, { client, directory: "/tmp" }, 10_000)
+
+    assert.equal(dueDuringPrompt, 9_000)
+    assert.notEqual(store.get(task.id).nextDueAt, 9_000)
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
 // ============== Tools-level ==============
 
 test("loop_schedule create uses ctx.sessionID", async () => {
@@ -410,6 +496,125 @@ test("loop_schedule create uses ctx.sessionID", async () => {
     )
     assert.equal(r.ok, true)
     assert.equal(r.task.sessionID, SID_A)
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("loop_schedule adaptive create persists a random fallback", async () => {
+  const { store, sched, dir } = makeScheduler(() => 0.5)
+  try {
+    const tools = await buildLoopTools(store, sched)
+    const r = JSON.parse(
+      await tools.loop_schedule.execute(
+        { action: "create", prompt: "tool-adaptive", mode: "adaptive" },
+        mockCtx(SID_A, dir)
+      )
+    )
+    const stored = store.get(r.task.id)
+    const delay = stored.nextDueAt - stored.createdAt
+    assert.ok(delay >= 1_830_000 && delay < 1_830_100, `unexpected midpoint delay ${delay}`)
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("loop_schedule stores in-range adaptive times without jitter and clamps only to bounds", async () => {
+  const { store, sched, dir } = makeScheduler(() => 0.5)
+  try {
+    const tools = await buildLoopTools(store, sched)
+    const task = await store.create({
+      prompt: "bounded",
+      mode: "adaptive",
+      adaptiveMinMs: 1_000,
+      adaptiveMaxMs: 3_000,
+      directory: dir,
+      sessionID: SID_A,
+    })
+
+    const belowRequested = Date.now() - 1
+    const belowStarted = Date.now()
+    const below = JSON.parse(
+      await tools.loop_schedule.execute(
+        { action: "reschedule", taskId: task.id, nextDueAtMs: belowRequested },
+        mockCtx(SID_A, dir)
+      )
+    )
+    assert.equal(below.requestedNextDueAt, new Date(belowRequested).toISOString())
+    assert.ok(Date.parse(below.task.nextDueAt) >= belowStarted + 1_000)
+    assert.ok(Date.parse(below.task.nextDueAt) <= Date.now() + 3_000)
+
+    const insideRequested = Date.now() + 2_000
+    const inside = JSON.parse(
+      await tools.loop_schedule.execute(
+        { action: "reschedule", taskId: task.id, nextDueAtMs: insideRequested },
+        mockCtx(SID_A, dir)
+      )
+    )
+    assert.equal(Date.parse(inside.task.nextDueAt), insideRequested)
+
+    const aboveRequested = Date.now() + 10_000
+    const aboveStarted = Date.now()
+    const above = JSON.parse(
+      await tools.loop_schedule.execute(
+        { action: "reschedule", taskId: task.id, nextDueAtMs: aboveRequested },
+        mockCtx(SID_A, dir)
+      )
+    )
+    assert.equal(above.requestedNextDueAt, new Date(aboveRequested).toISOString())
+    assert.ok(Date.parse(above.task.nextDueAt) >= aboveStarted + 1_000)
+    assert.ok(Date.parse(above.task.nextDueAt) <= Date.now() + 3_000)
+    assert.equal(store.get(task.id).nextDueAt, Date.parse(above.task.nextDueAt))
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("loop_schedule chooses a random fallback when adaptive reschedule omits time", async () => {
+  const { store, sched, dir } = makeScheduler(() => 0.5)
+  try {
+    const tools = await buildLoopTools(store, sched)
+    const task = await store.create({
+      prompt: "random",
+      mode: "adaptive",
+      adaptiveMinMs: 1_000,
+      adaptiveMaxMs: 3_000,
+      directory: dir,
+      sessionID: SID_A,
+    })
+    const started = Date.now()
+    const result = JSON.parse(
+      await tools.loop_schedule.execute(
+        { action: "reschedule", taskId: task.id },
+        mockCtx(SID_A, dir)
+      )
+    )
+    const delay = Date.parse(result.task.nextDueAt) - started
+    assert.ok(delay >= 2_000 && delay < 2_100, `unexpected midpoint delay ${delay}`)
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("loop_schedule keeps fixed reschedule times unrestricted", async () => {
+  const { store, sched, dir } = makeScheduler(() => 0.5)
+  try {
+    const tools = await buildLoopTools(store, sched)
+    const task = await store.create({
+      prompt: "fixed",
+      mode: "fixed",
+      intervalMs: 60_000,
+      directory: dir,
+      sessionID: SID_A,
+    })
+    const requested = 123_456
+    const result = JSON.parse(
+      await tools.loop_schedule.execute(
+        { action: "reschedule", taskId: task.id, nextDueAtMs: requested },
+        mockCtx(SID_A, dir)
+      )
+    )
+    assert.equal(Date.parse(result.task.nextDueAt), requested)
   } finally {
     rmSync(dir, { recursive: true })
   }

--- a/tests/scheduler.test.mjs
+++ b/tests/scheduler.test.mjs
@@ -8,7 +8,7 @@ import { Scheduler } from "../dist/scheduler.js"
 import { CronParser } from "../dist/cron-parser.js"
 import { Jitter } from "../dist/jitter.js"
 
-function makeScheduler(logger) {
+function makeScheduler(logger, random) {
   const dir = mkdtempSync(join(tmpdir(), "loop-sched-"))
   const store = new LoopStore({ storageDir: dir })
   const sched = new Scheduler({
@@ -18,6 +18,7 @@ function makeScheduler(logger) {
     adaptiveMinMs: 60_000,
     adaptiveMaxMs: 3_600_000,
     logger,
+    random,
   })
   return { sched, store, dir }
 }
@@ -47,6 +48,17 @@ test("/loop <prompt> → adaptive mode", async () => {
     assert.equal(r.task.adaptiveMinMs, 60_000)
     assert.equal(r.task.adaptiveMaxMs, 3_600_000)
     assert.equal(r.task.sessionID, "s1")
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("/loop <prompt> persists a random adaptive fallback on creation", async () => {
+  const { sched, dir } = makeScheduler(undefined, () => 0.5)
+  try {
+    const r = await sched.handleUserCommand("check the deploy", "/tmp", "s1")
+    const delay = r.task.nextDueAt - r.task.createdAt
+    assert.ok(delay >= 1_830_000 && delay < 1_830_100, `unexpected midpoint delay ${delay}`)
   } finally {
     rmSync(dir, { recursive: true })
   }
@@ -121,6 +133,23 @@ test("nextDueAt: maintenance → adaptiveMaxMs", async () => {
     const now = Date.now()
     const nd = await sched.nextDueAt(t, now)
     assert.equal(nd, now + 3_600_000)
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("nextDueAt: adaptive → random task-specific fallback", async () => {
+  const { sched, store, dir } = makeScheduler(undefined, () => 0.5)
+  try {
+    const t = await store.create({
+      prompt: "a",
+      mode: "adaptive",
+      adaptiveMinMs: 1_000,
+      adaptiveMaxMs: 3_000,
+      directory: "/tmp",
+      sessionID: "s1",
+    })
+    assert.equal(await sched.nextDueAt(t, 10_000), 12_000)
   } finally {
     rmSync(dir, { recursive: true })
   }


### PR DESCRIPTION
## Summary

- add a pure Adaptive scheduling policy with task-specific bounds and uniformly random fallback times
- let the model decide after each execution whether to keep the fallback, reschedule, or cancel
- persist the fallback before prompt injection so a successful model reschedule remains authoritative
- store in-range model-selected Adaptive times without Jitter and clamp only out-of-range requests
- keep Fixed and Maintenance scheduling behavior unchanged
- update the README for the 5-second ticker, Adaptive scheduling contract, upgrade flow, and supported OpenCode configuration
- release package version 0.2.10

## Validation

- `npm test` — 137 tests passed
- `npm publish --dry-run --access public` — passed, 34 package files
- real OpenCode 1.18.3 host test — Adaptive task rescheduled after the first execution and cancelled after the second
- npm registry verification — `latest` points to 0.2.10

## User impact

Adaptive `/loop <prompt>` tasks now always have a safe random fallback while allowing the model to choose a better next execution time from the actual result. Successful model scheduling is no longer overwritten after execution, and model-selected times do not receive Jitter.
