### PR TITLE
feat: ephemeral task lifecycle matching Claude Code's /loop (ephemeralTasks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A drop-in `/loop` command for [opencode](https://opencode.ai), modeled after Cla
 - **Internal ticker** — 5s loop drives task firing (no longer depends on `session.idle` events)
 - **Inflight guard** — double-set at ticker and `fireTask` level prevents double-firing even if opencode hot-reloads the plugin
 - **Persistent tasks** — survive session restarts; auto-migrated (tasks without `sessionID` are dropped on load)
+- **Ephemeral lifecycle (default)** — tasks die with the OpenCode process and are dropped on the next start, matching Claude Code's `/loop`. Set `ephemeralTasks: false` to persist tasks across process restarts
 - **Auto-cleanup on `session.deleted`** — all tasks for that session are cancelled automatically
 - **Configurable Jitter** — deterministic Fixed-task offset, controllable per command, tool call, or programmatic default
 - **Auto-expire** — tasks older than 7 days are removed on load
@@ -215,6 +216,17 @@ The built-in runtime defaults are:
 | Adaptive fallback range | 1 minute to 1 hour |
 | Scheduler ticker | 5 seconds |
 | New Fixed-task Jitter | enabled |
+| Ephemeral tasks | enabled |
+
+**Ephemeral lifecycle.** With `ephemeralTasks` enabled (the default), every
+`tasks.json` records the pid and start time of the process that wrote it. On
+load, tasks written by any other process — e.g. after OpenCode exits and
+restarts — are dropped, so loop tasks never outlive the process that created
+them (the same lifecycle as Claude Code's `/loop`). Same-process plugin reloads
+keep their tasks. Pass `{ ephemeralTasks: false }` in the plugin options to
+restore the previous behavior of persisting tasks across process restarts. Note
+that upgrading from a release without process-identity tracking drops the
+existing `tasks.json` once, since it carries no trusted writer identity.
 
 Adaptive minimum and maximum delays are persisted on each task. The random fallback
 and any model-requested `reschedule` are both constrained by that task's bounds. Jitter
@@ -238,11 +250,12 @@ Each `/loop` task carries a `sessionID` field:
 | User runs `/loop` in session B | Session B becomes active; A's task waits |
 | `session.deleted` for session A | All A's tasks cancelled automatically |
 | Plugin reload (`opencode` hot-reload) | Old tickers stop, new ticker starts; in-flight tasks guarded by `inflight` Set |
+| Process restart (new pid) | With `ephemeralTasks` enabled (default), all tasks from the previous process are dropped on load; with it disabled, tasks resume as before |
 | Old `tasks.json` without `sessionID` | Dropped on load (with log message) |
 
 ## Storage
 
-Tasks persist to `.opencode/cache/loop/tasks.json` (per project). Fire history is logged to `history.log` next to the store.
+Tasks persist to `.opencode/cache/loop/tasks.json` (per project). Fire history is logged to `history.log` next to the store. The state file also records the writer's `pid` and `startedAt`, which the ephemeral lifecycle uses to detect process restarts.
 
 ## Troubleshooting
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ const DEFAULT_CONFIG: Required<LoopConfig> = {
   defaultAdaptiveMaxMs: 3_600_000,
   tickerIntervalMs: 5_000,
   defaultJitterEnabled: true,
+  ephemeralTasks: true,
 }
 
 function commandAction(args: string): string {
@@ -70,6 +71,7 @@ export const LoopPlugin: Plugin = async (ctx) => {
     storageDir,
     maxTasks: config.maxTasks,
     taskTtlMs: config.taskTtlDays * 86_400_000,
+    ephemeralTasks: config.ephemeralTasks,
     logger,
   })
   await store.load()

--- a/src/store.ts
+++ b/src/store.ts
@@ -23,11 +23,26 @@ export interface LoopStoreOptions {
   maxTasks?: number
   taskTtlMs?: number
   logger?: LoopLogger
+  /**
+   * Ephemeral lifecycle (default true): tasks written by a different process are
+   * dropped on load. Process identity is tracked via pid + process start time so
+   * same-process plugin reloads keep their tasks.
+   */
+  ephemeralTasks?: boolean
+  /** Injectable process identity for tests; defaults to the current process. */
+  processIdentity?: ProcessIdentity
+}
+
+export interface ProcessIdentity {
+  pid: number
+  startedAt: number
 }
 
 interface PersistedState {
   version: 1
   tasks: LoopTask[]
+  pid?: number
+  startedAt?: number
 }
 
 interface LoopStoreInstance {
@@ -72,6 +87,18 @@ export function LoopStore(this: unknown, options?: LoopStoreOptions): LoopStoreI
   // in which case `this` is undefined in strict mode.
   void this
   let logger: LoopLogger = async () => {}
+  let ephemeralTasks = true
+  let identity: ProcessIdentity = {
+    pid: process.pid,
+    startedAt: Date.now() - process.uptime() * 1000,
+  }
+  /** Same-process reload keeps tasks; a different pid — or a recycled pid whose
+   *  recorded start time diverges — means the writer was a previous process. */
+  const PID_START_TOLERANCE_MS = 30_000
+  const isSameProcess = (state: PersistedState): boolean =>
+    state.pid === identity.pid &&
+    state.startedAt !== undefined &&
+    Math.abs(state.startedAt - identity.startedAt) <= PID_START_TOLERANCE_MS
   const inst: LoopStoreInstance = {
     state: { version: 1, tasks: [] },
     filePath: "",
@@ -87,6 +114,18 @@ export function LoopStore(this: unknown, options?: LoopStoreOptions): LoopStoreI
         const parsed = JSON.parse(raw) as PersistedState
         if (parsed.version !== 1) {
           throw new Error(`Unsupported state version: ${parsed.version}`)
+        }
+        if (ephemeralTasks && !isSameProcess(parsed)) {
+          const dropped = parsed.tasks.length
+          inst.state = { version: 1, tasks: [] }
+          await inst.persist()
+          if (dropped > 0) {
+            await logger("info", `ephemeral cleanup: dropped ${dropped} task(s) from previous process`, {
+              count: dropped,
+              previousPid: parsed.pid,
+            })
+          }
+          return
         }
         const cutoff = Date.now() - inst.taskTtlMs
         const filtered = parsed.tasks.filter((t) => t.createdAt > cutoff && !!t.sessionID)
@@ -113,6 +152,8 @@ export function LoopStore(this: unknown, options?: LoopStoreOptions): LoopStoreI
       }
     },
     persist: async () => {
+      inst.state.pid = identity.pid
+      inst.state.startedAt = identity.startedAt
       const tmp = `${inst.filePath}.tmp`
       mkdirSync(dirname(tmp), { recursive: true })
       writeFileSync(tmp, JSON.stringify(inst.state, null, 2), "utf-8")
@@ -265,6 +306,8 @@ export function LoopStore(this: unknown, options?: LoopStoreOptions): LoopStoreI
 
   if (options) {
     logger = options.logger ?? logger
+    ephemeralTasks = options.ephemeralTasks ?? true
+    identity = options.processIdentity ?? identity
     inst.filePath = join(options.storageDir, "tasks.json")
     inst.maxTasks = options.maxTasks ?? 50
     inst.taskTtlMs = options.taskTtlMs ?? 7 * 24 * 60 * 60 * 1000

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,12 @@ export interface LoopConfig {
   tickerIntervalMs?: number
   /** Default Jitter policy for newly created Fixed tasks (default true) */
   defaultJitterEnabled?: boolean
+  /**
+   * Ephemeral lifecycle (default true, matching Claude Code's /loop): tasks die
+   * with the opencode process and are dropped on the next load. Set to false to
+   * keep the legacy behavior of persisting tasks across process restarts.
+   */
+  ephemeralTasks?: boolean
 }
 
 export interface CreateTaskInput {

--- a/tests/integration.test.mjs
+++ b/tests/integration.test.mjs
@@ -264,6 +264,9 @@ test("plugin loads legacy tasks.json, drops orphans, keeps session-bound ones", 
       $: {},
       serverUrl: new URL("http://localhost:3000"),
       experimental_workspace: { register: () => {} },
+      // Legacy-file migration is exercised with the durable lifecycle; the
+      // ephemeral default intentionally drops no-pid files (covered below).
+      options: { ephemeralTasks: false },
     })
 
     // Should have only 1 task (the one with sessionID)
@@ -386,7 +389,11 @@ test("command failure becomes an error toast instead of rejecting", async () => 
       sessionID: "sA",
       paused: false,
     }))
-    writeFileSync(join(cacheDir, "tasks.json"), JSON.stringify({ version: 1, tasks }), "utf-8")
+    writeFileSync(
+      join(cacheDir, "tasks.json"),
+      JSON.stringify({ version: 1, pid: process.pid, startedAt: Date.now() - process.uptime() * 1000, tasks }),
+      "utf-8"
+    )
 
     const toastCalls = []
     const mockClient = {
@@ -519,6 +526,103 @@ test("toast transport failure is recorded in structured logs", async () => {
     assert.equal(logCalls[1].body.extra.error, "toast unavailable")
   } finally {
     if (hooks) await hooks.dispose()
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("ephemeral lifecycle: plugin reload in the same process keeps tasks", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "loop-int-"))
+  try {
+    const mockClient = { tui: { appendPrompt: async () => true } }
+    const ctx = () => ({
+      client: mockClient,
+      project: { id: "test" },
+      directory: dir,
+      worktree: dir,
+      $: {},
+      serverUrl: new URL("http://localhost:3000"),
+      experimental_workspace: { register: () => {} },
+    })
+
+    const first = await pluginModule.LoopPlugin(ctx())
+    await first["command.execute.before"](
+      { command: "loop", arguments: "1m ping", sessionID: "sA" },
+      { parts: [] }
+    )
+    await first.dispose()
+
+    // Simulate an in-process plugin reload (opencode re-inits plugins per command).
+    const second = await pluginModule.LoopPlugin(ctx())
+    const status = JSON.parse(
+      await second.tool.loop_status.execute({}, {
+        sessionID: "sA",
+        messageID: "m1",
+        agent: "build",
+        directory: dir,
+        worktree: dir,
+        abort: new AbortController().signal,
+        metadata: () => {},
+        ask: async () => {},
+      })
+    )
+    assert.equal(status.activeTasks, 1, "same-process reload keeps the task")
+    await second.dispose()
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("ephemeral lifecycle: foreign-pid tasks.json dropped by default, kept with ephemeralTasks: false", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "loop-int-"))
+  try {
+    const cacheDir = join(dir, ".opencode/cache/loop")
+    mkdirSync(cacheDir, { recursive: true })
+    const foreignState = () => ({
+      version: 1,
+      pid: 1,
+      startedAt: Date.now() - 86_400_000,
+      tasks: [
+        { id: "foreign", prompt: "from a dead process", mode: "fixed", intervalMs: 60_000, createdAt: Date.now(), lastFiredAt: 0, nextDueAt: Date.now() + 60_000, source: "user", directory: dir, sessionID: "sA", paused: false },
+      ],
+    })
+    const mockClient = { tui: { appendPrompt: async () => true } }
+    const ctx = (options) => ({
+      client: mockClient,
+      project: { id: "test" },
+      directory: dir,
+      worktree: dir,
+      $: {},
+      serverUrl: new URL("http://localhost:3000"),
+      experimental_workspace: { register: () => {} },
+      ...(options ? { options } : {}),
+    })
+    const toolCtx = {
+      sessionID: "sA",
+      messageID: "m1",
+      agent: "build",
+      directory: dir,
+      worktree: dir,
+      abort: new AbortController().signal,
+      metadata: () => {},
+      ask: async () => {},
+    }
+
+    // Default (ephemeral): task written by a dead process is dropped on load.
+    writeFileSync(join(cacheDir, "tasks.json"), JSON.stringify(foreignState()), "utf-8")
+    const ephemeralHooks = await pluginModule.LoopPlugin(ctx())
+    const dropped = JSON.parse(await ephemeralHooks.tool.loop_status.execute({}, toolCtx))
+    assert.equal(dropped.activeTasks, 0)
+    assert.equal(dropped.pausedTasks, 0)
+    await ephemeralHooks.dispose()
+
+    // Durable: same fixture is preserved.
+    writeFileSync(join(cacheDir, "tasks.json"), JSON.stringify(foreignState()), "utf-8")
+    const durableHooks = await pluginModule.LoopPlugin(ctx({ ephemeralTasks: false }))
+    const kept = JSON.parse(await durableHooks.tool.loop_status.execute({}, toolCtx))
+    assert.equal(kept.activeTasks, 1)
+    assert.equal(kept.tasks[0].id, "foreign")
+    await durableHooks.dispose()
+  } finally {
     rmSync(dir, { recursive: true })
   }
 })

--- a/tests/per-session.test.mjs
+++ b/tests/per-session.test.mjs
@@ -153,6 +153,8 @@ test("legacy tasks without sessionID are dropped on load", async () => {
   try {
     const data = {
       version: 1,
+      pid: process.pid,
+      startedAt: Date.now() - process.uptime() * 1000,
       tasks: [
         {
           id: "orphan1",

--- a/tests/store.test.mjs
+++ b/tests/store.test.mjs
@@ -11,6 +11,10 @@ function makeStore() {
   return { store, dir }
 }
 
+// Fixtures written by hand must carry the current process identity so the
+// ephemeral-lifecycle check (default on) treats them as same-process writes.
+const currentProcess = () => ({ pid: process.pid, startedAt: Date.now() - process.uptime() * 1000 })
+
 test("create + list task", async () => {
   const { store, dir } = makeStore()
   try {
@@ -122,6 +126,7 @@ test("expired tasks filtered on load", async () => {
   try {
     const data = {
       version: 1,
+      ...currentProcess(),
       tasks: [
         {
           id: "expired1",
@@ -167,6 +172,7 @@ test("orphan tasks (no sessionID) are dropped on load", async () => {
   try {
     const data = {
       version: 1,
+      ...currentProcess(),
       tasks: [
         // Legacy task without sessionID
         {
@@ -387,6 +393,7 @@ test("structured logger records task cleanup without console output", async () =
       join(dir, "tasks.json"),
       JSON.stringify({
         version: 1,
+        ...currentProcess(),
         tasks: [
           {
             id: "orphan",
@@ -466,6 +473,150 @@ test("structured logger records corrupted state without console output", async (
     console.log = originalLog
     console.warn = originalWarn
     console.error = originalError
+    rmSync(dir, { recursive: true })
+  }
+})
+
+// --- ephemeral lifecycle (process identity) ---
+
+test("ephemeral: same-process reload keeps tasks", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "loop-test-"))
+  try {
+    const identity = { pid: 4242, startedAt: Date.now() - 10_000 }
+    const s1 = new LoopStore({ storageDir: dir, processIdentity: identity })
+    await s1.load()
+    await s1.create({ prompt: "x", mode: "fixed", intervalMs: 60_000, directory: "/tmp", sessionID: "s1" })
+
+    const s2 = new LoopStore({ storageDir: dir, processIdentity: identity })
+    await s2.load()
+    assert.equal(s2.list().length, 1)
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("ephemeral: tasks from a previous process are dropped on load", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "loop-test-"))
+  try {
+    const s1 = new LoopStore({
+      storageDir: dir,
+      processIdentity: { pid: 1111, startedAt: Date.now() - 10_000 },
+    })
+    await s1.load()
+    await s1.create({ prompt: "x", mode: "fixed", intervalMs: 60_000, directory: "/tmp", sessionID: "s1" })
+
+    const logCalls = []
+    const s2 = new LoopStore({
+      storageDir: dir,
+      processIdentity: { pid: 2222, startedAt: Date.now() },
+      logger: async (level, message, extra) => logCalls.push({ level, message, extra }),
+    })
+    await s2.load()
+
+    assert.equal(s2.list().length, 0)
+    assert.equal(s2.state.pid, 2222, "new process identity adopted")
+    assert.equal(logCalls.length, 1)
+    assert.equal(logCalls[0].level, "info")
+    assert.match(logCalls[0].message, /ephemeral cleanup: dropped 1 task/)
+    assert.equal(logCalls[0].extra.previousPid, 1111)
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("ephemeralTasks: false keeps tasks from a previous process", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "loop-test-"))
+  try {
+    const s1 = new LoopStore({
+      storageDir: dir,
+      processIdentity: { pid: 1111, startedAt: Date.now() - 10_000 },
+    })
+    await s1.load()
+    await s1.create({ prompt: "x", mode: "fixed", intervalMs: 60_000, directory: "/tmp", sessionID: "s1" })
+
+    const s2 = new LoopStore({
+      storageDir: dir,
+      ephemeralTasks: false,
+      processIdentity: { pid: 2222, startedAt: Date.now() },
+    })
+    await s2.load()
+    assert.equal(s2.list().length, 1)
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("ephemeral: legacy state without pid is dropped; kept when ephemeralTasks is false", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "loop-test-"))
+  try {
+    const legacy = {
+      version: 1,
+      tasks: [
+        {
+          id: "legacy1",
+          prompt: "from v0.2.11",
+          mode: "fixed",
+          intervalMs: 60_000,
+          createdAt: Date.now(),
+          lastFiredAt: 0,
+          nextDueAt: Date.now() + 60_000,
+          source: "user",
+          directory: "/tmp",
+          sessionID: "s1",
+          paused: false,
+        },
+      ],
+    }
+    writeFileSync(join(dir, "tasks.json"), JSON.stringify(legacy), "utf-8")
+    const ephemeral = new LoopStore({ storageDir: dir })
+    await ephemeral.load()
+    assert.equal(ephemeral.list().length, 0, "legacy file cleaned under default ephemeral lifecycle")
+
+    writeFileSync(join(dir, "tasks.json"), JSON.stringify(legacy), "utf-8")
+    const durable = new LoopStore({ storageDir: dir, ephemeralTasks: false })
+    await durable.load()
+    assert.equal(durable.list().length, 1, "legacy file kept when ephemeralTasks is false")
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("ephemeral: recycled pid with divergent startedAt is treated as a new process", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "loop-test-"))
+  try {
+    const now = Date.now()
+    const s1 = new LoopStore({
+      storageDir: dir,
+      processIdentity: { pid: 3333, startedAt: now - 120_000 },
+    })
+    await s1.load()
+    await s1.create({ prompt: "x", mode: "fixed", intervalMs: 60_000, directory: "/tmp", sessionID: "s1" })
+
+    // Same pid but boot time is 2 minutes off — the pid was recycled by the OS.
+    const s2 = new LoopStore({
+      storageDir: dir,
+      processIdentity: { pid: 3333, startedAt: now },
+    })
+    await s2.load()
+    assert.equal(s2.list().length, 0)
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
+test("ephemeral: empty legacy state adopts identity without a cleanup log", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "loop-test-"))
+  try {
+    writeFileSync(join(dir, "tasks.json"), JSON.stringify({ version: 1, tasks: [] }), "utf-8")
+    const logCalls = []
+    const store = new LoopStore({
+      storageDir: dir,
+      logger: async (level, message, extra) => logCalls.push({ level, message, extra }),
+    })
+    await store.load()
+    assert.equal(store.state.pid, process.pid)
+    assert.equal(logCalls.length, 0, "nothing dropped, nothing logged")
+  } finally {
     rmSync(dir, { recursive: true })
   }
 })


### PR DESCRIPTION
## Summary

- Loop tasks now **die with the opencode process by default**, matching Claude Code's `/loop` lifecycle: `tasks.json` records the writer's `pid` + process start time, and on load any task written by a different process is dropped (with a structured `ephemeral cleanup` log).
- Same-process plugin reloads (opencode re-inits plugins per command) keep their tasks; recycled pids are detected via a 30s start-time tolerance.
- New `ephemeralTasks` option: set `false` to restore the previous persist-across-restarts behavior (programmatic composition, same mechanism as `defaultJitterEnabled`).
- Legacy `tasks.json` files (no writer identity) are dropped once on upgrade.

**BREAKING CHANGE**: loop tasks no longer survive process restarts by default.

## Test plan

- [x] `npm test` — 158/158 pass (8 new: same-pid reload keeps, foreign-pid drops, `ephemeralTasks: false` keeps, legacy no-pid file handling, recycled-pid detection, empty-state identity adoption, two integration lifecycle tests)
- [x] Real opencode E2E (isolated HOME, `file://` build, live model): create task → kill server → restart → resume session → task dropped with `ephemeral cleanup` log, `/loop list` empty, no catch-up fire
- [x] Same flow with `ephemeralTasks: false` (wrapper plugin): task survives restart and catch-up fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)