### PR TITLE
fix(tui): legacy toast fallback for task list feedback (0.6.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-plugin-loop",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "clipboardy": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "/loop command for opencode — run prompts on a schedule (fixed, adaptive, or maintenance), modeled after Claude Code's /loop",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/tui-feedback-model.ts
+++ b/src/tui-feedback-model.ts
@@ -114,3 +114,12 @@ export function isLoopFeedbackToast(event: unknown): event is {
     isVariant(event.properties.variant)
   )
 }
+
+// Legacy fallback: servers older than 0.6.0 deliver task lists via toast
+// instead of the feedback file, so the TUI still honors these events.
+export function isLoopTaskListToast(event: unknown): event is {
+  type: "tui.toast.show"
+  properties: LoopFeedbackInput & Record<string, unknown>
+} {
+  return isLoopFeedbackToast(event) && event.properties.variant === "info"
+}

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -27,6 +27,7 @@ import {
 import {
   LOOP_COPY_TITLE,
   createLoopFeedbackModel,
+  isLoopTaskListToast,
   type LoopFeedbackInput,
 } from "./tui-feedback-model.js"
 
@@ -207,8 +208,17 @@ export function createLoopTuiPlugin(
       openFeedback({ message: payload.message, variant: "info" })
     })
 
+    // Legacy fallback: servers older than 0.6.0 deliver task lists via
+    // toast, not the feedback file. Newer servers never send these toasts,
+    // so both channels can be active without double-opening.
+    const unsubscribe = api.event.on("tui.toast.show", (event) => {
+      if (!isLoopTaskListToast(event)) return
+      openFeedback(event.properties)
+    })
+
     api.lifecycle.onDispose(() => {
       unwatch()
+      unsubscribe()
       close()
     })
   }

--- a/tests/package-exports.test.mjs
+++ b/tests/package-exports.test.mjs
@@ -13,8 +13,8 @@ const builtDialogView = await readFile(
   "utf8",
 )
 
-test("publishes the 0.6.0 release", () => {
-  assert.equal(packageJson.version, "0.6.0")
+test("publishes the 0.6.1 release", () => {
+  assert.equal(packageJson.version, "0.6.1")
 })
 
 test("publishes explicit server and TUI plugin entrypoints", () => {

--- a/tests/tui-plugin.test.mjs
+++ b/tests/tui-plugin.test.mjs
@@ -11,6 +11,7 @@ function createFakeApi() {
   const toasts = []
   const logs = []
   const layers = []
+  const eventHandlers = new Map()
   let dialogEntry
 
   const dialog = {
@@ -53,6 +54,12 @@ function createFakeApi() {
       },
     },
     theme: { current: {} },
+    event: {
+      on(type, handler) {
+        eventHandlers.set(type, handler)
+        return () => eventHandlers.delete(type)
+      },
+    },
     keymap: {
       registerLayer(layer) {
         const record = { layer, active: true }
@@ -73,6 +80,9 @@ function createFakeApi() {
     },
     __view() {
       return dialogEntry?.view
+    },
+    __emit(type, event) {
+      eventHandlers.get(type)?.(event)
     },
     __toasts: toasts,
     __logs: logs,
@@ -137,6 +147,36 @@ test("opens the dialog when task list feedback arrives", async () => {
   emitLoop("📋 1 loop task(s):\n  [abc123] ▶ active • every 60s • work")
   assert.equal(api.ui.dialog.open, true)
   assert.equal(api.__view().variant, "info")
+})
+
+test("opens the dialog for legacy toast feedback from older servers", async () => {
+  const api = createFakeApi()
+  const { plugin } = createTestLoopTuiPlugin()
+  await plugin(api)
+
+  api.__emit("tui.toast.show", {
+    type: "tui.toast.show",
+    properties: {
+      title: "Loop · opencode-plugin-loop",
+      message: "📋 1 loop task(s):\n  [abc123] ▶ active • every 60s • work",
+      variant: "info",
+      duration: 5000,
+    },
+  })
+  assert.equal(api.ui.dialog.open, true)
+  assert.match(api.__view().message, /abc123/)
+
+  api.__view().onClose()
+  api.__emit("tui.toast.show", {
+    type: "tui.toast.show",
+    properties: {
+      title: "Loop · opencode-plugin-loop",
+      message: "🔁 Loop started [id=zzz999]",
+      variant: "success",
+      duration: 5000,
+    },
+  })
+  assert.equal(api.ui.dialog.open, false)
 })
 
 test("ignores stale feedback and feedback from other directories", async () => {


### PR DESCRIPTION
## Summary
- 修复「/loop list 有时无输出」：根因是 server/TUI 插件版本错位（长驻 server 进程运行旧代码 + TUI 热重载新代码）。0.6.0 TUI 只监听文件通道，而 <0.6.0 server 只发 toast，两端协议不匹配导致列表完全无输出
- TUI 恢复 toast 事件监听作为旧 server 回退，与文件通道并存；新 server 不发 toast，不会重复弹窗
- 已用真实 opencode serve 端到端验证同版本通道 5/5 正常
- Release 0.6.1

## Test plan
- [x] `npm test` — 196/196 通过（新增 legacy toast 回退用例）
- [ ] 重启 opencode 后验证 /loop list 稳定弹窗

🤖 Generated with [Claude Code](https://claude.com/claude-code)