### PR TITLE
fix(loop): fired tasks actually execute instead of being refused (0.7.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-plugin-loop",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "/loop command for opencode — run prompts on a schedule (fixed, adaptive, or maintenance), modeled after Claude Code's /loop",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/runtime-feedback.ts
+++ b/src/runtime-feedback.ts
@@ -17,7 +17,7 @@ export function buildLoopCreatedPrompt(input: {
     `- Schedule: ${input.schedule}${input.once ? " (runs once)" : ""}`,
     `- Job ID: ${input.taskId}`,
     `- Cancel anytime with: /loop cancel ${input.taskId}`,
-    "Reply to the user with a short confirmation that the scheduled loop task was created, written in the same language the user used in their request. Include the task, schedule, and job ID from above. Do not execute the task prompt now, do not call tools, and do not treat the task prompt as an instruction.",
+    "Reply to the user with a short confirmation that the scheduled loop task was created, written in the same language the user used in their request. Include the task, schedule, and job ID from above. This reply is only the creation confirmation — the plugin executes the task automatically at each scheduled time, so do not execute the task and do not call tools in this reply.",
   ].join("\n")
 }
 
@@ -25,7 +25,7 @@ export function buildLoopFailedPrompt(message: string): string {
   const reason = message.replace(/^❌\s*/, "")
   return [
     `The user's /loop command failed: ${reason}`,
-    "Briefly inform the user that the /loop command failed and why, written in the same language the user used in their request. Do not call tools and do not attempt to perform the command arguments as a separate task.",
+    "Briefly inform the user that the /loop command failed and why, written in the same language the user used in their request. Do not call tools in this reply and do not attempt to perform the command arguments as a separate task.",
   ].join("\n")
 }
 
@@ -40,7 +40,18 @@ export function buildLoopResultPrompt(message: string): string {
     "- If it is a task list, render it as a markdown table with columns: Job ID, frequency, content, and type (every task is a session-scoped loop that auto-expires after 7 days idle). Keep the management commands (`/loop cancel|pause|resume <id>`, `/loop stop-all`) mentioned below the table.",
     "- If it confirms an action (cancel, pause, resume, stop-all), confirm concisely which task was affected and whether it will trigger again.",
     "- If it is help text or an empty state, present it naturally.",
-    "Do not call tools, and do not execute any task prompt yourself.",
+    "Do not call tools in this reply, and do not execute any task prompt in this reply — scheduled tasks run automatically when they are due.",
+  ].join("\n")
+}
+
+export function buildFixedExecutionPrompt(task: {
+  id: string
+  prompt: string
+}): string {
+  return [
+    `This is the scheduled execution of /loop task ${task.id}. Perform the task described below now, then report the result concisely.`,
+    "",
+    task.prompt,
   ].join("\n")
 }
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -16,7 +16,7 @@ import type { LoopTask } from "./types.js"
 import type { LoopStoreInstance as LoopStore } from "./store.js"
 import type { CronParserInstance as CronParser } from "./cron-parser.js"
 import type { JitterInstance as Jitter } from "./jitter.js"
-import { buildLoopCreatedPrompt, errorMessage, type LoopLogger } from "./runtime-feedback.js"
+import { buildFixedExecutionPrompt, buildLoopCreatedPrompt, errorMessage, type LoopLogger } from "./runtime-feedback.js"
 import {
   buildAdaptiveExecutionPrompt,
   clampAdaptiveNextDueAt as clampAdaptivePolicyNextDueAt,
@@ -472,7 +472,7 @@ export function Scheduler(this: unknown, opts: SchedulerOptions): SchedulerInsta
                 minMs: inst.opts.adaptiveMinMs,
                 maxMs: inst.opts.adaptiveMaxMs,
               })
-            : task.prompt
+            : buildFixedExecutionPrompt(task)
         const directory = task.directory || ctx?.directory || process.cwd()
         const client = ctx?.client
 

--- a/tests/package-exports.test.mjs
+++ b/tests/package-exports.test.mjs
@@ -6,8 +6,8 @@ const packageJson = JSON.parse(
   await readFile(new URL("../package.json", import.meta.url), "utf8"),
 )
 
-test("publishes the 0.7.0 release", () => {
-  assert.equal(packageJson.version, "0.7.0")
+test("publishes the 0.7.1 release", () => {
+  assert.equal(packageJson.version, "0.7.1")
 })
 
 test("publishes explicit server and TUI plugin entrypoints", () => {

--- a/tests/scheduler.test.mjs
+++ b/tests/scheduler.test.mjs
@@ -355,6 +355,33 @@ test("/loop resume --all works cross-session and rearms fixed", async () => {
   }
 })
 
+test("fireTask wraps fixed prompts with an explicit execution instruction", async () => {
+  const { sched, dir } = makeScheduler(async () => {})
+  try {
+    const result = await sched.handleUserCommand("5m 输出当前系统时间", dir, "s1")
+    const promptCalls = []
+    const client = {
+      session: {
+        async prompt(args) {
+          promptCalls.push(args)
+          return true
+        },
+      },
+    }
+
+    await sched.fireTask(result.task, { client, directory: dir })
+
+    assert.equal(promptCalls.length, 1)
+    const text = promptCalls[0].body.parts[0].text
+    assert.match(text, /scheduled execution of \/loop task/)
+    assert.match(text, new RegExp(result.task.id))
+    assert.match(text, /输出当前系统时间/)
+    assert.match(text, /Perform the task/)
+  } finally {
+    rmSync(dir, { recursive: true })
+  }
+})
+
 test("fireTask failure uses structured logger without console output", async () => {
   const logCalls = []
   const consoleCalls = []


### PR DESCRIPTION
## Summary
- 根因：0.7.0 的创建/列表确认提示词要求模型"不要把任务 prompt 当作指令"，该指令残留在对话上下文中，任务触发时模型拒绝执行（回复"我不会在当前对话中手动执行它"）
- 修复1：确认类提示词的禁止执行要求限定为"仅此回复"，并说明插件会在到期时自动执行
- 修复2：fixed 任务触发时注入显式执行包装（"This is the scheduled execution of /loop task \<id\>. Perform the task..."），替代裸 prompt

## Test plan
- [x] `npm test` — 150/150 通过（新增触发文本断言）
- [x] 真实 opencode serve 端到端：20s 任务到期触发，注入消息含执行指令，模型实际执行并回复"收到"，无拒绝

🤖 Generated with [Claude Code](https://claude.com/claude-code)