### PR TITLE
chore: release 0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-plugin-loop",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "/loop command for opencode — run prompts on a schedule (fixed, adaptive, or maintenance), modeled after Claude Code's /loop",
   "type": "module",
   "main": "./dist/index.js",

--- a/tests/package-exports.test.mjs
+++ b/tests/package-exports.test.mjs
@@ -6,8 +6,8 @@ const packageJson = JSON.parse(
   await readFile(new URL("../package.json", import.meta.url), "utf8"),
 )
 
-test("publishes the 0.7.2 release", () => {
-  assert.equal(packageJson.version, "0.7.2")
+test("publishes the 0.7.3 release", () => {
+  assert.equal(packageJson.version, "0.7.3")
 })
 
 test("publishes explicit server and TUI plugin entrypoints", () => {


### PR DESCRIPTION
## Summary

Version bump to 0.7.3, releasing the already-merged run-mode fixes:

- issue #18: `opencode run "/loop ..."` (headless / `-i`) never emits `command.execute.before`, so raw command text reached the model and every deterministic guard was bypassed. The plugin now intercepts literal `/loop ...` text in `chat.message` and runs the same parser (`runLoopCommand` shared by both hooks).
- Follow-up: strip `opencode run` argv re-quoting before fallback matching; scan all text parts.

## Test plan

- [x] `npm test` — 176/176 (12 run-mode tests included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
