### PR TITLE
test: unpin hard-coded version in package-exports test

### DIFF
--- a/tests/package-exports.test.mjs
+++ b/tests/package-exports.test.mjs
@@ -6,8 +6,8 @@ const packageJson = JSON.parse(
   await readFile(new URL("../package.json", import.meta.url), "utf8"),
 )
 
-test("publishes the 0.8.1 release", () => {
-  assert.equal(packageJson.version, "0.8.1")
+test("publishes the current release version", () => {
+  assert.match(packageJson.version, /^\d+\.\d+\.\d+$/)
 })
 
 test("publishes explicit server and TUI plugin entrypoints", () => {


### PR DESCRIPTION
## 内容

`package-exports.test.mjs` 中把钉死的 `0.8.1` 版本断言改为 semver 格式校验，避免每次发版测试必挂。

## 验证

`npm test`：190/190 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)